### PR TITLE
Phase 3: Geheugen/context via pattern storage en recall

### DIFF
--- a/src/neuraxon_agent/__init__.py
+++ b/src/neuraxon_agent/__init__.py
@@ -4,7 +4,7 @@ from neuraxon_agent.perception import PerceptionEncoder
 from neuraxon_agent.action import ActionDecoder, AgentAction
 from neuraxon_agent.tissue import AgentTissue, TissueState
 from neuraxon_agent.modulation import Modulation, ModulationFeedback
-from neuraxon_agent.memory import Memory
+from neuraxon_agent.memory import Memory, TissueMemory, ExperiencePattern
 from neuraxon_agent.evolution import Evolution
 
 __all__ = [
@@ -16,5 +16,7 @@ __all__ = [
     "Modulation",
     "ModulationFeedback",
     "Memory",
+    "TissueMemory",
+    "ExperiencePattern",
     "Evolution",
 ]

--- a/src/neuraxon_agent/memory.py
+++ b/src/neuraxon_agent/memory.py
@@ -1,6 +1,17 @@
-"""Memory layer — experience storage and retrieval."""
+"""Memory layer — experience storage and retrieval via Neuraxon pattern recall."""
 
+from __future__ import annotations
+
+import json
+import math
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
 from typing import Any
+
+from neuraxon_agent.perception import PerceptionEncoder
+from neuraxon_agent.action import AgentAction
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters, NeuraxonApplication
 
 
 class Memory:
@@ -23,3 +34,281 @@ class Memory:
     def clear(self) -> None:
         """Erase all stored episodes."""
         self.episodes.clear()
+
+
+@dataclass
+class ExperiencePattern:
+    """A single stored experience as a Neuraxon pattern."""
+
+    name: str
+    pattern: list[int]
+    observation: dict[str, Any]
+    action: AgentAction
+    outcome: str
+    created_at: float
+    strength: float = 1.0
+    access_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "pattern": self.pattern,
+            "observation": self.observation,
+            "action": {
+                "actie_type": self.action.actie_type,
+                "confidence": self.action.confidence,
+                "raw_output": list(self.action.raw_output),
+            },
+            "outcome": self.outcome,
+            "created_at": self.created_at,
+            "strength": self.strength,
+            "access_count": self.access_count,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExperiencePattern:
+        action_data = data["action"]
+        action = AgentAction(
+            actie_type=action_data["actie_type"],
+            confidence=action_data["confidence"],
+            raw_output=tuple(action_data["raw_output"]),
+        )
+        return cls(
+            name=data["name"],
+            pattern=list(data["pattern"]),
+            observation=dict(data["observation"]),
+            action=action,
+            outcome=data["outcome"],
+            created_at=data["created_at"],
+            strength=data.get("strength", 1.0),
+            access_count=data.get("access_count", 0),
+        )
+
+
+class TissueMemory:
+    """Pattern-based memory for an AgentTissue using NeuraxonApplication storage/recall.
+
+    Each experience (observation-action-outcome triplet) is encoded as a trinary
+    pattern and stored in a :class:`~neuraxon_agent.vendor.neuraxon2.NeuraxonApplication`.
+    Patterns are recalled by similarity (Hamming distance on trinary vectors) and
+    can be partially reconstructed by the network through associative completion.
+
+    Forgetting is implemented as gradual strength decay.  Old patterns with low
+    strength are automatically pruned when *capacity* is reached.
+    """
+
+    def __init__(
+        self,
+        params: NetworkParameters | None = None,
+        capacity: int = 100,
+        forgetting_rate: float = 0.001,
+        strength_threshold: float = 0.1,
+    ) -> None:
+        self.params = params or NetworkParameters()
+        self.app = NeuraxonApplication(self.params)
+        self.encoder = PerceptionEncoder(self.params.num_input_neurons)
+        self.capacity = capacity
+        self.forgetting_rate = forgetting_rate
+        self.strength_threshold = strength_threshold
+        self.experiences: dict[str, ExperiencePattern] = {}
+        self._step_counter = 0
+        self._pattern_counter = 0
+
+    # ----------------------------------------------------------------- core ---
+
+    def store_experience(
+        self,
+        observation: dict[str, Any],
+        action: AgentAction,
+        outcome: str,
+        steps: int = 20,
+    ) -> str:
+        """Encode *observation* as a pattern and store the experience.
+
+        Returns the generated experience ID.
+        """
+        self._step_counter += 1
+        self._pattern_counter += 1
+        name = f"exp_{self._pattern_counter:06d}"
+
+        pattern = self.encoder.encode(observation)
+        self.app.store_pattern(name, pattern, steps=steps)
+
+        # Apply forgetting before storing
+        self._decay_strengths()
+
+        exp = ExperiencePattern(
+            name=name,
+            pattern=pattern,
+            observation=dict(observation),
+            action=action,
+            outcome=outcome,
+            created_at=float(self._step_counter),
+        )
+        self.experiences[name] = exp
+
+        # Prune weakest if over capacity
+        self._prune_if_needed()
+
+        return name
+
+    def recall_similar(
+        self,
+        observation: dict[str, Any],
+        top_k: int = 1,
+        steps: int = 20,
+        mask_fraction: float = 0.3,
+    ) -> list[ExperiencePattern]:
+        """Recall the *top_k* experiences most similar to *observation*.
+
+        Similarity is measured by Hamming distance on the encoded trinary
+        patterns.  Accessing a pattern boosts its strength (rehearsal effect).
+        The network performs associative completion by presenting a masked
+        version of the closest pattern.
+        """
+        if not self.experiences:
+            return []
+
+        query = self.encoder.encode(observation)
+
+        # Rank by similarity (higher is better)
+        scored: list[tuple[float, str]] = []
+        for name, exp in self.experiences.items():
+            sim = self._pattern_similarity(query, exp.pattern) * exp.strength
+            scored.append((sim, name))
+
+        scored.sort(reverse=True)
+        top_names = [name for _, name in scored[:top_k]]
+
+        results: list[ExperiencePattern] = []
+        for name in top_names:
+            exp = self.experiences[name]
+            # Rehearsal boost
+            exp.access_count += 1
+            exp.strength = min(1.0, exp.strength + 0.05)
+            # Associative completion via network
+            self.app.recall_pattern(name, steps=steps, mask_fraction=mask_fraction)
+            results.append(exp)
+
+        return results
+
+    # ----------------------------------------------------------- forgetting ---
+
+    def _decay_strengths(self) -> None:
+        """Age all patterns by one step."""
+        for exp in self.experiences.values():
+            exp.strength *= 1.0 - self.forgetting_rate
+            exp.strength = max(0.0, exp.strength)
+
+    def _prune_if_needed(self) -> None:
+        """Remove weakest patterns when over capacity."""
+        while len(self.experiences) > self.capacity:
+            weakest_name = min(
+                self.experiences,
+                key=lambda n: self.experiences[n].strength,
+            )
+            del self.experiences[weakest_name]
+            # Also remove from app patterns dict if present
+            self.app.patterns.pop(weakest_name, None)
+
+    def forget_weak(self) -> int:
+        """Explicitly remove patterns below *strength_threshold*.
+
+        Returns the number of patterns removed.
+        """
+        to_remove = [
+            name for name, exp in self.experiences.items()
+            if exp.strength < self.strength_threshold
+        ]
+        for name in to_remove:
+            del self.experiences[name]
+            self.app.patterns.pop(name, None)
+        return len(to_remove)
+
+    # ---------------------------------------------------------- internals ---
+
+    @staticmethod
+    def _pattern_similarity(a: list[int], b: list[int]) -> float:
+        """Compute normalised similarity between two trinary patterns.
+
+        Returns a value in ``[0.0, 1.0]`` where 1.0 means identical.
+        """
+        n = max(len(a), len(b))
+        if n == 0:
+            return 0.0
+        matches = 0
+        for i in range(n):
+            av = a[i] if i < len(a) else 0
+            bv = b[i] if i < len(b) else 0
+            if av == bv:
+                matches += 1
+        return matches / n
+
+    # ----------------------------------------------------------- state mgmt ---
+
+    def save(self, path: str) -> None:
+        """Serialize memory state (patterns + metadata) to JSON."""
+        data = {
+            "params": {
+                "num_input_neurons": self.params.num_input_neurons,
+                "num_hidden_neurons": self.params.num_hidden_neurons,
+                "num_output_neurons": self.params.num_output_neurons,
+            },
+            "capacity": self.capacity,
+            "forgetting_rate": self.forgetting_rate,
+            "strength_threshold": self.strength_threshold,
+            "step_counter": self._step_counter,
+            "pattern_counter": self._pattern_counter,
+            "experiences": [exp.to_dict() for exp in self.experiences.values()],
+            "patterns": {
+                name: pattern for name, pattern in self.app.patterns.items()
+                if name in self.experiences
+            },
+        }
+        Path(path).write_text(json.dumps(data, indent=2))
+
+    @classmethod
+    def load(cls, path: str) -> TissueMemory:
+        """Deserialize memory state from JSON."""
+        data = json.loads(Path(path).read_text())
+        params_data = data.get("params", {})
+        params = NetworkParameters(
+            num_input_neurons=params_data.get("num_input_neurons", 5),
+            num_hidden_neurons=params_data.get("num_hidden_neurons", 20),
+            num_output_neurons=params_data.get("num_output_neurons", 5),
+        )
+        instance = cls(
+            params=params,
+            capacity=data.get("capacity", 100),
+            forgetting_rate=data.get("forgetting_rate", 0.001),
+            strength_threshold=data.get("strength_threshold", 0.1),
+        )
+        instance._step_counter = data.get("step_counter", 0)
+        instance._pattern_counter = data.get("pattern_counter", 0)
+        instance.experiences = {
+            exp_data["name"]: ExperiencePattern.from_dict(exp_data)
+            for exp_data in data.get("experiences", [])
+        }
+        instance.app.patterns = {
+            name: list(pattern) for name, pattern in data.get("patterns", {}).items()
+        }
+        return instance
+
+    # --------------------------------------------------------------- introspection ---
+
+    def __len__(self) -> int:
+        return len(self.experiences)
+
+    def get_stats(self) -> dict[str, Any]:
+        """Return summary statistics about the memory contents."""
+        if not self.experiences:
+            return {"count": 0, "mean_strength": 0.0, "oldest_step": 0}
+        strengths = [e.strength for e in self.experiences.values()]
+        return {
+            "count": len(self.experiences),
+            "mean_strength": round(sum(strengths) / len(strengths), 4),
+            "min_strength": round(min(strengths), 4),
+            "max_strength": round(max(strengths), 4),
+            "oldest_step": int(min(e.created_at for e in self.experiences.values())),
+            "newest_step": int(max(e.created_at for e in self.experiences.values())),
+        }

--- a/src/neuraxon_agent/tissue.py
+++ b/src/neuraxon_agent/tissue.py
@@ -10,6 +10,7 @@ from neuraxon_agent.vendor.neuraxon2 import NetworkParameters, NeuraxonNetwork
 from neuraxon_agent.perception import PerceptionEncoder
 from neuraxon_agent.action import ActionDecoder, AgentAction
 from neuraxon_agent.modulation import ModulationFeedback
+from neuraxon_agent.memory import TissueMemory
 
 
 @dataclass
@@ -36,6 +37,7 @@ class AgentTissue:
         self.decoder = ActionDecoder(self.params.num_output_neurons)
         self._last_observation: dict[str, Any] | None = None
         self._feedback = ModulationFeedback()
+        self.memory = TissueMemory(self.params)
 
     def observe(self, observation: dict[str, Any]) -> None:
         """Encode an observation and feed it to the network input neurons."""
@@ -65,19 +67,39 @@ class AgentTissue:
         """Return the :class:`ModulationFeedback` instance used by this tissue."""
         return self._feedback
 
+    def store_experience(self, action: AgentAction, outcome: str) -> str:
+        """Store the current observation + *action* + *outcome* in tissue memory.
+
+        Returns the experience ID.
+        """
+        if self._last_observation is None:
+            raise RuntimeError("No observation to store; call observe() first.")
+        return self.memory.store_experience(self._last_observation, action, outcome)
+
+    def recall_similar(self, observation: dict[str, Any] | None = None, top_k: int = 1) -> list:
+        """Recall experiences similar to *observation* (or the last observation)."""
+        obs = observation if observation is not None else self._last_observation
+        if obs is None:
+            raise RuntimeError("No observation to recall against; call observe() first.")
+        return self.memory.recall_similar(obs, top_k=top_k)
+
     def save(self, path: str) -> None:
-        """Serialize network state to JSON."""
+        """Serialize tissue and memory state to JSON."""
         data = self.network.to_dict()
         data["_params"] = {
             "num_input_neurons": self.params.num_input_neurons,
             "num_hidden_neurons": self.params.num_hidden_neurons,
             "num_output_neurons": self.params.num_output_neurons,
         }
+        # Save memory alongside network
+        memory_path = str(Path(path).with_suffix("")) + ".memory.json"
+        self.memory.save(memory_path)
+        data["_memory_path"] = memory_path
         Path(path).write_text(json.dumps(data, indent=2))
 
     @classmethod
     def load(cls, path: str) -> AgentTissue:
-        """Deserialize network state from JSON."""
+        """Deserialize tissue and memory state from JSON."""
         data = json.loads(Path(path).read_text())
         params_data = data.pop("_params", {})
         params = NetworkParameters(
@@ -87,6 +109,10 @@ class AgentTissue:
         )
         instance = cls(params)
         # TODO: restore full network state from dict when upstream supports from_dict
+        # Restore memory if saved alongside
+        memory_path = data.pop("_memory_path", None)
+        if memory_path and Path(memory_path).exists():
+            instance.memory = TissueMemory.load(memory_path)
         return instance
 
     @property

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,254 @@
+"""Tests for TissueMemory and AgentTissue memory coupling."""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from neuraxon_agent.memory import TissueMemory, ExperiencePattern, Memory
+from neuraxon_agent.action import AgentAction
+from neuraxon_agent.tissue import AgentTissue
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
+
+
+# ---------------------------------------------------------------------------
+# TissueMemory basics
+# ---------------------------------------------------------------------------
+
+
+def test_memory_init() -> None:
+    mem = TissueMemory()
+    assert len(mem) == 0
+    assert mem.capacity == 100
+
+
+def test_memory_store_experience() -> None:
+    mem = TissueMemory(params=NetworkParameters(num_input_neurons=3))
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0))
+    obs = {"tool_result": "success"}
+    exp_id = mem.store_experience(obs, action, "success")
+    assert exp_id.startswith("exp_")
+    assert len(mem) == 1
+
+
+def test_memory_recall_similar() -> None:
+    mem = TissueMemory(params=NetworkParameters(num_input_neurons=3))
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0))
+
+    # Store two experiences with different observations
+    mem.store_experience({"tool_result": "success"}, action, "success")
+    mem.store_experience({"tool_result": "fail"}, action, "failure")
+
+    # Recall should return the closest match
+    results = mem.recall_similar({"tool_result": "success"}, top_k=1)
+    assert len(results) == 1
+    assert results[0].outcome == "success"
+
+
+def test_memory_recall_similar_returns_related() -> None:
+    """Vergelijkbare observaties roepen gerelateerde memories op."""
+    mem = TissueMemory(params=NetworkParameters(num_input_neurons=5))
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0, 0, 0))
+
+    mem.store_experience({"tool_result": "success", "error_type": None}, action, "success")
+    mem.store_experience({"tool_result": "fail", "error_type": "runtime"}, action, "failure")
+    mem.store_experience({"tool_result": "success", "error_type": None}, action, "success")
+
+    # A success-like observation should prefer success outcomes
+    results = mem.recall_similar({"tool_result": "success", "error_type": None}, top_k=2)
+    outcomes = [r.outcome for r in results]
+    assert "success" in outcomes
+
+
+def test_memory_recall_boosts_strength() -> None:
+    mem = TissueMemory(params=NetworkParameters(num_input_neurons=3))
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0))
+    mem.store_experience({"tool_result": "success"}, action, "success")
+    pre_access = mem.experiences["exp_000001"].access_count
+    mem.recall_similar({"tool_result": "success"})
+    post_access = mem.experiences["exp_000001"].access_count
+    assert post_access > pre_access
+    # Strength may already be capped at 1.0; access_count is the reliable signal
+    assert mem.experiences["exp_000001"].strength == 1.0
+
+
+def test_memory_forgetting() -> None:
+    mem = TissueMemory(
+        params=NetworkParameters(num_input_neurons=3),
+        forgetting_rate=0.5,
+    )
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0))
+    mem.store_experience({"tool_result": "success"}, action, "success")
+    initial_strength = mem.experiences["exp_000001"].strength
+
+    # Store another experience to trigger decay
+    mem.store_experience({"tool_result": "fail"}, action, "failure")
+    new_strength = mem.experiences["exp_000001"].strength
+    assert new_strength < initial_strength
+
+
+def test_memory_forget_weak() -> None:
+    mem = TissueMemory(
+        params=NetworkParameters(num_input_neurons=3),
+        forgetting_rate=0.9,
+        strength_threshold=0.2,
+    )
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0))
+    mem.store_experience({"tool_result": "success"}, action, "success")
+    # Store many more to decay the first one heavily
+    for i in range(20):
+        mem.store_experience({"tool_result": "fail", "index": i}, action, "failure")
+
+    removed = mem.forget_weak()
+    assert removed > 0
+    assert "exp_000001" not in mem.experiences
+
+
+def test_memory_capacity_pruning() -> None:
+    mem = TissueMemory(
+        params=NetworkParameters(num_input_neurons=3),
+        capacity=5,
+        forgetting_rate=0.0,
+    )
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0))
+    for i in range(10):
+        mem.store_experience({"tool_result": "success", "index": i}, action, "success")
+
+    assert len(mem) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Save / load
+# ---------------------------------------------------------------------------
+
+
+def test_memory_save_load() -> None:
+    mem = TissueMemory(params=NetworkParameters(num_input_neurons=3))
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0))
+    mem.store_experience({"tool_result": "success"}, action, "success")
+    mem.store_experience({"tool_result": "fail"}, action, "failure")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "memory.json"
+        mem.save(str(path))
+        assert path.exists()
+
+        loaded = TissueMemory.load(str(path))
+        assert len(loaded) == 2
+        assert "exp_000001" in loaded.experiences
+        assert loaded.experiences["exp_000001"].outcome == "success"
+        assert loaded.experiences["exp_000002"].outcome == "failure"
+
+
+def test_memory_save_load_survives_roundtrip() -> None:
+    """Geheugen overleeft save() / load()."""
+    params = NetworkParameters(num_input_neurons=3)
+    mem = TissueMemory(params=params, capacity=50, forgetting_rate=0.01)
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0))
+    mem.store_experience({"tool_result": "success"}, action, "success")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "memory.json"
+        mem.save(str(path))
+        loaded = TissueMemory.load(str(path))
+        assert loaded.capacity == 50
+        assert loaded.forgetting_rate == 0.01
+        assert len(loaded) == 1
+        results = loaded.recall_similar({"tool_result": "success"})
+        assert len(results) == 1
+        assert results[0].outcome == "success"
+
+
+# ---------------------------------------------------------------------------
+# AgentTissue coupling
+# ---------------------------------------------------------------------------
+
+
+def test_tissue_has_memory() -> None:
+    tissue = AgentTissue()
+    assert hasattr(tissue, "memory")
+    assert isinstance(tissue.memory, TissueMemory)
+
+
+def test_tissue_store_experience() -> None:
+    params = NetworkParameters(num_input_neurons=3, num_hidden_neurons=5, num_output_neurons=2)
+    tissue = AgentTissue(params)
+    tissue.observe({"tool_result": "success"})
+    action = tissue.think(steps=5)
+    exp_id = tissue.store_experience(action, "success")
+    assert exp_id.startswith("exp_")
+    assert len(tissue.memory) == 1
+
+
+def test_tissue_recall_similar() -> None:
+    params = NetworkParameters(num_input_neurons=3, num_hidden_neurons=5, num_output_neurons=2)
+    tissue = AgentTissue(params)
+    tissue.observe({"tool_result": "success"})
+    action = tissue.think(steps=5)
+    tissue.store_experience(action, "success")
+
+    results = tissue.recall_similar({"tool_result": "success"})
+    assert len(results) == 1
+    assert results[0].outcome == "success"
+
+
+def test_tissue_save_load_with_memory() -> None:
+    """Tissue save/load roundtrip preserves memory."""
+    params = NetworkParameters(num_input_neurons=3, num_hidden_neurons=5, num_output_neurons=2)
+    tissue = AgentTissue(params)
+    tissue.observe({"tool_result": "success"})
+    action = tissue.think(steps=5)
+    tissue.store_experience(action, "success")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "state.json"
+        tissue.save(str(path))
+        assert path.exists()
+
+        tissue2 = AgentTissue.load(str(path))
+        assert len(tissue2.memory) == 1
+        results = tissue2.memory.recall_similar({"tool_result": "success"})
+        assert len(results) == 1
+        assert results[0].outcome == "success"
+
+
+def test_tissue_store_experience_without_observation_raises() -> None:
+    tissue = AgentTissue()
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0))
+    with pytest.raises(RuntimeError):
+        tissue.store_experience(action, "success")
+
+
+def test_tissue_recall_without_observation_raises() -> None:
+    tissue = AgentTissue()
+    with pytest.raises(RuntimeError):
+        tissue.recall_similar()
+
+
+# ---------------------------------------------------------------------------
+# Old Memory backward compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_old_memory_still_works() -> None:
+    mem = Memory(capacity=10)
+    mem.store({"episode": 1})
+    assert len(mem.recall(1)) == 1
+    mem.clear()
+    assert len(mem.recall(1)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Stats / introspection
+# ---------------------------------------------------------------------------
+
+
+def test_memory_stats() -> None:
+    mem = TissueMemory(params=NetworkParameters(num_input_neurons=3))
+    action = AgentAction(actie_type="PROCEED", confidence=0.8, raw_output=(1, 0, 0))
+    mem.store_experience({"tool_result": "success"}, action, "success")
+    stats = mem.get_stats()
+    assert stats["count"] == 1
+    assert stats["mean_strength"] > 0.0


### PR DESCRIPTION
## Samenvatting
Implementeert TissueMemory voor agent context en ervaringsherinnering via Neuraxon pattern storage/recall.

## Wijzigingen
- **TissueMemory** klasse in 
  -  — encodeert observatie als trinary pattern en slaat op in NeuraxonApplication
  -  — vindt beste match via Hamming distance op encoded patterns
  - **Forgetting** — strength decay per store-operatie, pruning onder threshold/capacity
- **AgentTissue** koppeling
  -  attribuut
  -  en  methoden
  -  /  persisteren nu ook memory state
- **Tests** — 18 testcases, allemaal groen

## Acceptatiecriteria checklist
- [x] Opgeslagen experience is terug te roepen
- [x] Vergelijkbare observaties roepen gerelateerde memories op
- [x] Geheugen overleeft  / 
- [x] Oude memories worden geleidelijk minder prominent

Closes #9