### PR TITLE
feat: add benchmark harness

### DIFF
--- a/src/neuraxon_agent/__init__.py
+++ b/src/neuraxon_agent/__init__.py
@@ -1,13 +1,19 @@
 """Neuraxon Agent — Intelligence Tissue for CLI AI Agents."""
 
-from neuraxon_agent.perception import PerceptionEncoder
 from neuraxon_agent.action import ActionDecoder, AgentAction
-from neuraxon_agent.tissue import AgentTissue, TissueState
-from neuraxon_agent.modulation import Modulation
-from neuraxon_agent.memory import Memory
+from neuraxon_agent.benchmark import (
+    BenchmarkHarness,
+    BenchmarkReport,
+    BenchmarkResult,
+    BenchmarkScenario,
+)
 from neuraxon_agent.evolution import AgentEvolution, EvolutionConfig
-from neuraxon_agent.streaming import StreamingLoop, StreamEvent
-from neuraxon_agent.persistence import save_state, load_state
+from neuraxon_agent.memory import Memory
+from neuraxon_agent.modulation import Modulation
+from neuraxon_agent.perception import PerceptionEncoder
+from neuraxon_agent.persistence import load_state, save_state
+from neuraxon_agent.streaming import StreamEvent, StreamingLoop
+from neuraxon_agent.tissue import AgentTissue, TissueState
 
 __all__ = [
     "PerceptionEncoder",
@@ -23,4 +29,8 @@ __all__ = [
     "StreamEvent",
     "save_state",
     "load_state",
+    "BenchmarkHarness",
+    "BenchmarkReport",
+    "BenchmarkResult",
+    "BenchmarkScenario",
 ]

--- a/src/neuraxon_agent/benchmark.py
+++ b/src/neuraxon_agent/benchmark.py
@@ -1,0 +1,151 @@
+"""Benchmark harness for Neuraxon agent scenarios.
+
+The harness runs deterministic scenario definitions through an ``AgentTissue``
+instance and records raw per-scenario metrics for later analysis.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from time import perf_counter
+from typing import Any, Callable
+
+from neuraxon_agent.tissue import AgentTissue
+
+TissueFactory = Callable[[], AgentTissue]
+
+
+@dataclass(frozen=True)
+class BenchmarkScenario:
+    """A benchmark scenario for evaluating an agent tissue.
+
+    Attributes
+    ----------
+    name:
+        Human-readable scenario identifier.
+    observation_sequence:
+        Ordered observations that will be fed into the tissue.
+    expected_optimal_action:
+        Action type considered optimal for the final observation.
+    difficulty:
+        Difficulty score for grouping/reporting benchmark runs.
+    """
+
+    name: str
+    observation_sequence: list[dict[str, Any]]
+    expected_optimal_action: str
+    difficulty: float
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Raw metrics collected for one scenario run."""
+
+    scenario_name: str
+    expected_optimal_action: str
+    difficulty: float
+    observation_count: int
+    action: str
+    confidence: float
+    outcome: str
+    elapsed_seconds: float
+    neuromodulator_levels: dict[str, float]
+
+
+@dataclass(frozen=True)
+class BenchmarkReport:
+    """Complete benchmark report for a harness run."""
+
+    scenario_count: int
+    run_count: int
+    success_count: int
+    total_elapsed_seconds: float
+    results: list[BenchmarkResult]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of this report."""
+        return asdict(self)
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        """Export raw benchmark results as valid JSON."""
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+
+class BenchmarkHarness:
+    """Run benchmark scenarios and collect per-run metrics.
+
+    Parameters
+    ----------
+    tissue_factory:
+        Factory called once per scenario to create a fresh tissue. Passing a
+        factory keeps benchmark scenarios isolated from each other.
+    steps_per_observation:
+        Number of tissue simulation steps to run after each observation.
+    """
+
+    def __init__(
+        self,
+        tissue_factory: TissueFactory | None = None,
+        steps_per_observation: int = 10,
+    ) -> None:
+        if steps_per_observation < 1:
+            raise ValueError("steps_per_observation must be >= 1")
+        self.tissue_factory = tissue_factory or AgentTissue
+        self.steps_per_observation = steps_per_observation
+
+    def run(self, scenarios: list[BenchmarkScenario]) -> BenchmarkReport:
+        """Run all *scenarios* and return a raw metrics report."""
+        start = perf_counter()
+        results = [self.run_one(scenario) for scenario in scenarios]
+        total_elapsed = perf_counter() - start
+        success_count = sum(1 for result in results if result.outcome == "success")
+        return BenchmarkReport(
+            scenario_count=len(scenarios),
+            run_count=len(results),
+            success_count=success_count,
+            total_elapsed_seconds=total_elapsed,
+            results=results,
+        )
+
+    def run_one(self, scenario: BenchmarkScenario) -> BenchmarkResult:
+        """Run one scenario against a fresh tissue and collect raw metrics."""
+        if not scenario.observation_sequence:
+            raise ValueError("scenario observation_sequence must not be empty")
+
+        tissue = self.tissue_factory()
+        start = perf_counter()
+        action = None
+        for observation in scenario.observation_sequence:
+            tissue.observe(observation)
+            action = tissue.think(steps=self.steps_per_observation)
+
+        if action is None:  # defensive; empty sequences are rejected above
+            raise RuntimeError("scenario produced no action")
+
+        outcome = self._score_action(action.actie_type, scenario.expected_optimal_action)
+        tissue.modulate(outcome)
+        elapsed = perf_counter() - start
+        state = tissue.state
+
+        return BenchmarkResult(
+            scenario_name=scenario.name,
+            expected_optimal_action=scenario.expected_optimal_action,
+            difficulty=scenario.difficulty,
+            observation_count=len(scenario.observation_sequence),
+            action=action.actie_type,
+            confidence=action.confidence,
+            outcome=outcome,
+            elapsed_seconds=elapsed,
+            neuromodulator_levels={
+                "dopamine": state.dopamine,
+                "serotonin": state.serotonin,
+                "acetylcholine": state.acetylcholine,
+                "norepinephrine": state.norepinephrine,
+            },
+        )
+
+    @staticmethod
+    def _score_action(action: str, expected_optimal_action: str) -> str:
+        """Map an action match to a simple benchmark outcome label."""
+        return "success" if action == expected_optimal_action else "failure"

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,103 @@
+"""Tests for benchmark scenario harness."""
+
+from __future__ import annotations
+
+import json
+
+from neuraxon_agent.benchmark import BenchmarkHarness, BenchmarkScenario
+from neuraxon_agent.tissue import AgentTissue
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
+
+
+def make_tissue() -> AgentTissue:
+    params = NetworkParameters(num_input_neurons=3, num_hidden_neurons=5, num_output_neurons=2)
+    return AgentTissue(params)
+
+
+def test_benchmark_scenario_dataclass_keeps_required_fields() -> None:
+    scenario = BenchmarkScenario(
+        name="simple-success",
+        observation_sequence=[{"type": "prompt", "content": "hello"}],
+        expected_optimal_action="PAUSE",
+        difficulty=0.25,
+    )
+
+    assert scenario.name == "simple-success"
+    assert scenario.observation_sequence == [{"type": "prompt", "content": "hello"}]
+    assert scenario.expected_optimal_action == "PAUSE"
+    assert scenario.difficulty == 0.25
+
+
+def test_harness_collects_action_confidence_outcome_timing_and_modulators() -> None:
+    harness = BenchmarkHarness(tissue_factory=make_tissue, steps_per_observation=1)
+    scenario = BenchmarkScenario(
+        name="one-step",
+        observation_sequence=[{"type": "prompt", "content": "hello"}],
+        expected_optimal_action="PAUSE",
+        difficulty=0.1,
+    )
+
+    report = harness.run([scenario])
+
+    assert report.scenario_count == 1
+    assert report.run_count == 1
+    result = report.results[0]
+    assert result.scenario_name == "one-step"
+    assert result.action in {"PROCEED", "PAUSE", "RETRY", "ESCALATE", "EXPLORE"}
+    assert 0.0 <= result.confidence <= 1.0
+    assert result.outcome in {"success", "failure"}
+    assert result.elapsed_seconds >= 0.0
+    assert set(result.neuromodulator_levels) == {
+        "dopamine",
+        "serotonin",
+        "acetylcholine",
+        "norepinephrine",
+    }
+
+
+def test_harness_exports_valid_json_with_all_required_fields() -> None:
+    harness = BenchmarkHarness(tissue_factory=make_tissue, steps_per_observation=1)
+    scenario = BenchmarkScenario(
+        name="json-export",
+        observation_sequence=[{"type": "prompt", "content": "hello"}],
+        expected_optimal_action="PAUSE",
+        difficulty=0.2,
+    )
+
+    payload = harness.run([scenario]).to_json()
+    data = json.loads(payload)
+
+    assert data["scenario_count"] == 1
+    assert data["run_count"] == 1
+    assert data["success_count"] in {0, 1}
+    assert isinstance(data["total_elapsed_seconds"], float)
+    result = data["results"][0]
+    assert result["scenario_name"] == "json-export"
+    assert result["expected_optimal_action"] == "PAUSE"
+    assert result["difficulty"] == 0.2
+    assert "action" in result
+    assert "confidence" in result
+    assert "outcome" in result
+    assert "elapsed_seconds" in result
+    assert "neuromodulator_levels" in result
+    assert "observation_count" in result
+
+
+def test_harness_runs_100_scenarios_without_crashing() -> None:
+    scenarios = [
+        BenchmarkScenario(
+            name=f"scenario-{i}",
+            observation_sequence=[{"type": "prompt", "content": f"item {i}"}],
+            expected_optimal_action="PAUSE",
+            difficulty=(i % 10) / 10,
+        )
+        for i in range(100)
+    ]
+    harness = BenchmarkHarness(tissue_factory=make_tissue, steps_per_observation=1)
+
+    report = harness.run(scenarios)
+
+    assert report.scenario_count == 100
+    assert report.run_count == 100
+    assert len(report.results) == 100
+    json.loads(report.to_json())


### PR DESCRIPTION
## Summary
- Adds `BenchmarkScenario`, `BenchmarkResult`, `BenchmarkReport`, and `BenchmarkHarness`.
- Runs scenario observation sequences through fresh `AgentTissue` instances.
- Records action, confidence, outcome, elapsed time, observation count, difficulty, expected action, and neuromodulator levels.
- Adds JSON export for raw benchmark reports.
- Adds tests for required scenario fields, metrics collection, JSON export, and 100-scenario execution.

Closes #28

## Verification
- `uv run pytest tests/test_benchmark.py -q` → 4 passed
- `uv run ruff check src/neuraxon_agent/benchmark.py tests/test_benchmark.py src/neuraxon_agent/__init__.py` → passed
- `uv run mypy src/neuraxon_agent/benchmark.py` → passed

## Note
Full suite still has the four pre-existing failures seen before this issue work:
- `tests/test_cli.py::test_cli_help`
- `tests/test_end_to_end.py::test_full_agent_loop`
- `tests/test_end_to_end.py::test_evolution_integration`
- `tests/test_evolution.py::test_evolution_reproducible`
