### PR TITLE
feat: add benchmark baseline agents

### DIFF
--- a/src/neuraxon_agent/__init__.py
+++ b/src/neuraxon_agent/__init__.py
@@ -1,6 +1,12 @@
 """Neuraxon Agent — Intelligence Tissue for CLI AI Agents."""
 
 from neuraxon_agent.action import ActionDecoder, AgentAction
+from neuraxon_agent.baselines import (
+    AlwaysExecuteAgent,
+    BaselineAgentState,
+    RandomAgent,
+    run_baseline_benchmarks,
+)
 from neuraxon_agent.benchmark import (
     BenchmarkHarness,
     BenchmarkReport,
@@ -34,6 +40,10 @@ __all__ = [
     "BenchmarkReport",
     "BenchmarkResult",
     "BenchmarkScenario",
+    "AlwaysExecuteAgent",
+    "BaselineAgentState",
+    "RandomAgent",
+    "run_baseline_benchmarks",
     "MOCK_AGENT_ACTIONS",
     "load_mock_agent_scenarios",
 ]

--- a/src/neuraxon_agent/baselines.py
+++ b/src/neuraxon_agent/baselines.py
@@ -1,0 +1,134 @@
+"""Baseline agents for benchmark comparisons."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Any
+
+from neuraxon_agent.action import AgentAction
+from neuraxon_agent.benchmark import (
+    BenchmarkHarness,
+    BenchmarkReport,
+    BenchmarkScenario,
+    TissueFactory,
+)
+from neuraxon_agent.scenarios import MOCK_AGENT_ACTIONS
+
+
+@dataclass(frozen=True)
+class BaselineAgentState:
+    """Observable no-op state for baseline agents.
+
+    Baselines intentionally do not maintain neuromodulator dynamics, but the
+    benchmark harness expects a tissue-like ``state`` object. These counters make
+    runs observable while keeping dopamine-like fields neutral.
+    """
+
+    observation_count: int
+    think_count: int
+    modulation_count: int
+    dopamine: float = 0.0
+    serotonin: float = 0.0
+    acetylcholine: float = 0.0
+    norepinephrine: float = 0.0
+
+
+class RandomAgent:
+    """Baseline that chooses a random action regardless of observation input."""
+
+    def __init__(self, *, seed: int | None = None, actions: set[str] | None = None) -> None:
+        self._actions = tuple(sorted(actions or MOCK_AGENT_ACTIONS))
+        if not self._actions:
+            raise ValueError("RandomAgent requires at least one action")
+        self._rng = random.Random(seed)
+        self._observation_count = 0
+        self._think_count = 0
+        self._modulation_count = 0
+        self._last_observation: dict[str, Any] | None = None
+
+    def observe(self, observation: dict[str, Any]) -> None:
+        """Record that an observation was received."""
+        self._last_observation = observation
+        self._observation_count += 1
+
+    def think(self, steps: int = 10) -> AgentAction:
+        """Return one uniformly sampled action from the mock action space."""
+        del steps
+        self._think_count += 1
+        return AgentAction(
+            actie_type=self._rng.choice(self._actions),
+            confidence=1 / len(self._actions),
+            raw_output=(),
+        )
+
+    def modulate(self, outcome: str) -> dict[str, float]:
+        """No-op modulation hook matching ``AgentTissue``."""
+        del outcome
+        self._modulation_count += 1
+        return {}
+
+    @property
+    def state(self) -> BaselineAgentState:
+        """Return observable neutral state for benchmark reporting."""
+        return BaselineAgentState(
+            observation_count=self._observation_count,
+            think_count=self._think_count,
+            modulation_count=self._modulation_count,
+        )
+
+
+class AlwaysExecuteAgent:
+    """Baseline that always returns ``execute`` regardless of input."""
+
+    def __init__(self) -> None:
+        self._observation_count = 0
+        self._think_count = 0
+        self._modulation_count = 0
+        self._last_observation: dict[str, Any] | None = None
+
+    def observe(self, observation: dict[str, Any]) -> None:
+        """Record that an observation was received."""
+        self._last_observation = observation
+        self._observation_count += 1
+
+    def think(self, steps: int = 10) -> AgentAction:
+        """Always choose the execute action."""
+        del steps
+        self._think_count += 1
+        return AgentAction(actie_type="execute", confidence=1.0, raw_output=())
+
+    def modulate(self, outcome: str) -> dict[str, float]:
+        """No-op modulation hook matching ``AgentTissue``."""
+        del outcome
+        self._modulation_count += 1
+        return {}
+
+    @property
+    def state(self) -> BaselineAgentState:
+        """Return observable neutral state for benchmark reporting."""
+        return BaselineAgentState(
+            observation_count=self._observation_count,
+            think_count=self._think_count,
+            modulation_count=self._modulation_count,
+        )
+
+
+def run_baseline_benchmarks(
+    scenarios: list[BenchmarkScenario],
+    *,
+    random_seed: int | None = 0,
+    harness: BenchmarkHarness | None = None,
+) -> dict[str, BenchmarkReport]:
+    """Run built-in baseline agents over *scenarios*.
+
+    Returns reports keyed by stable agent names so later benchmark/reporting
+    steps can compare them with the Neuraxon tissue report.
+    """
+    runner = harness or BenchmarkHarness()
+    seed_source = random.Random(random_seed)
+    factories: dict[str, TissueFactory] = {
+        "random": lambda: RandomAgent(seed=seed_source.randrange(2**32)),
+        "always_execute": AlwaysExecuteAgent,
+    }
+    return runner.run_agents(scenarios, factories)

--- a/src/neuraxon_agent/benchmark.py
+++ b/src/neuraxon_agent/benchmark.py
@@ -9,11 +9,26 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass
 from time import perf_counter
-from typing import Any, Callable
+from typing import Any, Callable, Protocol
 
+from neuraxon_agent.action import AgentAction
 from neuraxon_agent.tissue import AgentTissue
 
-TissueFactory = Callable[[], AgentTissue]
+
+class BenchmarkAgent(Protocol):
+    """Minimal tissue-like interface required by the benchmark harness."""
+
+    def observe(self, observation: dict[str, Any]) -> None: ...
+
+    def think(self, steps: int = 10) -> AgentAction: ...
+
+    def modulate(self, outcome: str) -> dict[str, float]: ...
+
+    @property
+    def state(self) -> Any: ...
+
+
+TissueFactory = Callable[[], BenchmarkAgent]
 
 
 @dataclass(frozen=True)
@@ -109,6 +124,20 @@ class BenchmarkHarness:
             total_elapsed_seconds=total_elapsed,
             results=results,
         )
+
+    def run_agents(
+        self,
+        scenarios: list[BenchmarkScenario],
+        agent_factories: dict[str, TissueFactory],
+    ) -> dict[str, BenchmarkReport]:
+        """Run the same scenarios for multiple named tissue-like agents."""
+        return {
+            agent_name: BenchmarkHarness(
+                tissue_factory=factory,
+                steps_per_observation=self.steps_per_observation,
+            ).run(scenarios)
+            for agent_name, factory in agent_factories.items()
+        }
 
     def run_one(self, scenario: BenchmarkScenario) -> BenchmarkResult:
         """Run one scenario against a fresh tissue and collect raw metrics."""

--- a/tests/test_baseline_agents.py
+++ b/tests/test_baseline_agents.py
@@ -1,0 +1,110 @@
+"""Tests for mock benchmark baseline agents."""
+
+from __future__ import annotations
+
+from neuraxon_agent.baselines import (
+    AlwaysExecuteAgent,
+    BaselineAgentState,
+    RandomAgent,
+    run_baseline_benchmarks,
+)
+from neuraxon_agent.benchmark import BenchmarkHarness, BenchmarkScenario
+from neuraxon_agent.scenarios import MOCK_AGENT_ACTIONS, load_mock_agent_scenarios
+from neuraxon_agent.tissue import AgentTissue
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
+
+
+def test_random_agent_implements_tissue_interface_and_uses_known_actions() -> None:
+    agent = RandomAgent(seed=7)
+
+    agent.observe({"type": "tool_request", "tool_name": "calendar"})
+    action = agent.think(steps=5)
+    deltas = agent.modulate("success")
+
+    assert action.actie_type in MOCK_AGENT_ACTIONS
+    assert 0.0 <= action.confidence <= 1.0
+    assert action.raw_output == ()
+    assert deltas == {}
+    assert isinstance(agent.state, BaselineAgentState)
+    assert agent.state.observation_count == 1
+    assert agent.state.think_count == 1
+    assert agent.state.modulation_count == 1
+
+
+def test_always_execute_agent_implements_tissue_interface_and_ignores_input() -> None:
+    agent = AlwaysExecuteAgent()
+
+    agent.observe({"type": "ambiguous_prompt", "content": "maybe do a thing"})
+    first = agent.think()
+    agent.observe({"type": "failed_tool_call", "error": "timeout"})
+    second = agent.think(steps=99)
+
+    assert first.actie_type == "execute"
+    assert second.actie_type == "execute"
+    assert first.confidence == 1.0
+    assert second.confidence == 1.0
+    assert agent.modulate("failure") == {}
+    assert agent.state.observation_count == 2
+    assert agent.state.think_count == 2
+
+
+def test_benchmark_harness_can_run_multiple_agent_factories() -> None:
+    scenarios = [
+        BenchmarkScenario(
+            name="execute-case",
+            observation_sequence=[{"type": "tool_request"}],
+            expected_optimal_action="execute",
+            difficulty=1,
+        ),
+        BenchmarkScenario(
+            name="retry-case",
+            observation_sequence=[{"type": "failed_tool_call"}],
+            expected_optimal_action="retry",
+            difficulty=3,
+        ),
+    ]
+    harness = BenchmarkHarness()
+
+    reports = harness.run_agents(
+        scenarios,
+        {
+            "neuraxon": lambda: AgentTissue(
+                NetworkParameters(
+                    num_input_neurons=3,
+                    num_hidden_neurons=5,
+                    num_output_neurons=2,
+                )
+            ),
+            "random": lambda: RandomAgent(seed=3),
+            "always_execute": AlwaysExecuteAgent,
+        },
+    )
+
+    assert set(reports) == {"neuraxon", "random", "always_execute"}
+    assert reports["neuraxon"].scenario_count == 2
+    assert reports["random"].scenario_count == 2
+    assert reports["always_execute"].scenario_count == 2
+    assert reports["always_execute"].success_count == 1
+
+
+def test_baseline_runner_executes_all_mock_scenarios_with_expected_accuracy_shape() -> None:
+    scenarios = load_mock_agent_scenarios()
+
+    reports = run_baseline_benchmarks(scenarios, random_seed=0)
+
+    assert set(reports) == {"random", "always_execute"}
+    random_accuracy = reports["random"].success_count / reports["random"].run_count
+    always_execute_accuracy = (
+        reports["always_execute"].success_count / reports["always_execute"].run_count
+    )
+
+    assert 0.12 <= random_accuracy <= 0.22
+    assert always_execute_accuracy == 40 / 140
+
+    always_execute_results = reports["always_execute"].results
+    execute_results = [r for r in always_execute_results if r.expected_optimal_action == "execute"]
+    non_execute_results = [
+        r for r in always_execute_results if r.expected_optimal_action != "execute"
+    ]
+    assert all(result.outcome == "success" for result in execute_results)
+    assert all(result.outcome == "failure" for result in non_execute_results)


### PR DESCRIPTION
## Summary
- Adds `RandomAgent` and `AlwaysExecuteAgent` baseline agents with the same `observe()`, `think()`, and `modulate()` interface as `AgentTissue`.
- Adds neutral observable baseline state so benchmark reports can collect neuromodulator fields without special-casing baselines.
- Extends `BenchmarkHarness` with `run_agents()` so the same scenario set can run across Neuraxon, random, and always-execute agents.
- Adds `run_baseline_benchmarks()` helper and exports the baseline APIs.

## Verification
- `uv run pytest tests/test_baseline_agents.py tests/test_benchmark.py tests/test_mock_scenarios.py -q` → 13 passed
- `uv run ruff check src/neuraxon_agent/baselines.py src/neuraxon_agent/benchmark.py src/neuraxon_agent/__init__.py tests/test_baseline_agents.py` → passed
- `uv run mypy src/neuraxon_agent/baselines.py src/neuraxon_agent/benchmark.py` → passed
- Baseline smoke metrics on 140 mock scenarios:
  - random: 22/140 = 15.71%
  - always_execute: 40/140 = 28.57%
- Full suite remains at 143 passed, 4 failed due pre-existing failures:
  - `tests/test_cli.py::test_cli_help`
  - `tests/test_end_to_end.py::test_full_agent_loop`
  - `tests/test_end_to_end.py::test_evolution_integration`
  - `tests/test_evolution.py::test_evolution_reproducible`

Closes #30
