### PR TITLE
fix: clear issue 50 suite failures

### DIFF
--- a/src/neuraxon_agent/cli.py
+++ b/src/neuraxon_agent/cli.py
@@ -9,8 +9,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from neuraxon_agent.tissue import AgentTissue, TissueState
 from neuraxon_agent.evolution import AgentEvolution, EvolutionConfig
+from neuraxon_agent.tissue import AgentTissue, TissueState
 from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
 
 
@@ -182,7 +182,10 @@ def main(argv: list[str] | None = None) -> int:
     p_load.add_argument("--output", "-o", required=True, help="Result JSON file")
     p_load.set_defaults(func=cmd_load)
 
-    args = parser.parse_args(argv)
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code or 0)
     if args.command is None:
         parser.print_help()
         return 2

--- a/src/neuraxon_agent/evolution.py
+++ b/src/neuraxon_agent/evolution.py
@@ -1,15 +1,14 @@
 """Evolutionary training for agent behaviour using Aigarth hybrid algorithm."""
 from __future__ import annotations
 
-import copy
 import json
 import random
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
 from neuraxon_agent.vendor.MultiNeuraxon2 import NeuraxonAigarthHybrid
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
 
 
 @dataclass
@@ -21,12 +20,27 @@ class EvolutionConfig:
     task_scenarios: list[dict[str, Any]] | None = None
 
 
+def _normalize_config(config: EvolutionConfig | dict[str, Any] | None) -> EvolutionConfig:
+    """Return an ``EvolutionConfig`` for public API inputs."""
+    if config is None:
+        return EvolutionConfig()
+    if isinstance(config, EvolutionConfig):
+        return config
+    return EvolutionConfig(**config)
+
+
 class AgentEvolution:
     """Wraps NeuraxonAigarthHybrid to evolve agent networks on task scenarios."""
 
-    def __init__(self, params: NetworkParameters | None = None, config: EvolutionConfig | None = None) -> None:
+    def __init__(
+        self,
+        params: NetworkParameters | None = None,
+        config: EvolutionConfig | dict[str, Any] | None = None,
+    ) -> None:
         self.params = params or NetworkParameters()
-        self.config = config or EvolutionConfig()
+        self.config = _normalize_config(config)
+        if self.config.seed is not None:
+            random.seed(self.config.seed)
         self.hybrid = NeuraxonAigarthHybrid(self.params)
         self._history: list[dict[str, Any]] = []
 
@@ -52,7 +66,11 @@ class AgentEvolution:
             random.seed(self.config.seed)
         dataset = self._build_dataset()
         initial_best = self.evaluate_fitness()
-        self.hybrid.evolve(dataset, seasons=self.config.seasons, episodes=self.config.episodes_per_season)
+        self.hybrid.evolve(
+            dataset,
+            seasons=self.config.seasons,
+            episodes=self.config.episodes_per_season,
+        )
         final_best = self.evaluate_fitness()
         summary = {
             "initial_fitness": initial_best,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -43,8 +43,22 @@ def test_harness_collects_action_confidence_outcome_timing_and_modulators() -> N
     assert report.run_count == 1
     result = report.results[0]
     assert result.scenario_name == "one-step"
-    assert result.action in {"execute", "query", "retry", "assertive", "explore"}
-    assert result.decoded_action in {"PROCEED", "PAUSE", "RETRY", "ESCALATE", "EXPLORE"}
+    assert result.action in {
+        "execute",
+        "query",
+        "retry",
+        "assertive",
+        "explore",
+        "cautious",
+    }
+    assert result.decoded_action in {
+        "PROCEED",
+        "PAUSE",
+        "RETRY",
+        "ESCALATE",
+        "EXPLORE",
+        "CAUTIOUS",
+    }
     assert 0.0 <= result.confidence <= 1.0
     assert result.outcome in {"success", "failure"}
     assert result.elapsed_seconds >= 0.0

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from neuraxon_agent import AgentTissue, PerceptionEncoder, ActionDecoder, AgentEvolution
-from neuraxon_agent.tissue import AgentTissue
+from neuraxon_agent import ActionDecoder, AgentEvolution
+from neuraxon_agent.action_contract import normalize_benchmark_action
+from neuraxon_agent.persistence import load_state, save_state
 from neuraxon_agent.streaming import StreamingLoop
-from neuraxon_agent.persistence import save_state, load_state
+from neuraxon_agent.tissue import AgentTissue
 from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
 
 
@@ -21,7 +22,15 @@ def test_full_agent_loop() -> None:
 
     # Think
     action = tissue.think(steps=5)
-    assert action.actie_type in ("idle", "execute", "query", "respond", "explore", "retry")
+    assert action.actie_type in ActionDecoder.get_all_defined_actions()
+    assert normalize_benchmark_action(action.actie_type) in (
+        "execute",
+        "query",
+        "retry",
+        "assertive",
+        "explore",
+        "cautious",
+    )
 
     # Modulate
     tissue.modulate("success")


### PR DESCRIPTION
## Summary
- Makes CLI help invocations return exit code 0 instead of leaking argparse SystemExit.
- Normalizes AgentEvolution config input from dict or EvolutionConfig and seeds randomness before Aigarth population initialization.
- Makes end-to-end and benchmark tests explicit about the decoder-action to benchmark-action contract, including CAUTIOUS/cautious.

## Verification
- uv run --extra dev pytest tests/test_cli.py::test_cli_help tests/test_end_to_end.py::test_full_agent_loop tests/test_end_to_end.py::test_evolution_integration tests/test_evolution.py::test_evolution_reproducible tests/test_benchmark.py::test_harness_collects_action_confidence_outcome_timing_and_modulators -q
- uv run --extra dev pytest tests/ -q
- uv run --extra dev ruff check src/neuraxon_agent/cli.py src/neuraxon_agent/evolution.py tests/test_end_to_end.py tests/test_benchmark.py

## Notes
- Full pytest suite passes locally: 173 passed.
- Full-repo ruff/mypy still report broad pre-existing vendor and legacy lint/type issues outside this scoped fix; changed files pass scoped ruff.

Closes #50
