### PR TITLE
test: expand temporal dynamics benchmark

### DIFF
--- a/benchmarks/results/analysis/benchmark_report.md
+++ b/benchmarks/results/analysis/benchmark_report.md
@@ -8,7 +8,7 @@ Resultaat: `neuraxon_tissue` haalt nu 700/700 correcte runs = 100.00% accuracy. 
 
 Een extra holdout/noisy generalization smoke benchmark haalt nog altijd 140/140 correcte runs = 100.00%, maar dat resultaat is nu expliciet gedegradeerd van “pass” naar `needs_temporal_dynamics_evidence`: alle 140 finale observaties zijn direct oplosbaar door de expliciete semantic policy bridge (`semantic_policy_coverage=100%`). Dat bevestigt je vermoeden: 100% is hier vooral oracle-/feature-coverage, niet bewijs voor emergente Neuraxon-dynamiek.
 
-Daarom is er nu een NIA-geïnspireerde temporal dynamics probe toegevoegd. Die verbergt de finale actie-oracle in een generieke `temporal_decision_probe`; de relevante signalen zitten alleen in eerdere observaties. Op die strengere probe haalt `neuraxon_tissue` 1/6 = 16.67%, gelijk aan always-execute en onder random (33.33% op deze kleine set). Dit is het juiste kritische signaal: de huidige slice bewijst een nuttige semantische adapter, maar nog geen continue-tijd/stateful/neuromodulated generalisatie.
+Daarom is de NIA-geïnspireerde temporal dynamics probe uitgebreid van 6 smoke cases naar 108 gegenereerde scenario's: 6 actie-archetypes × 3 dataset-seeds × 3 sequentielengtes × 2 varianten. De finale actie-oracle zit verborgen in een generieke `temporal_decision_probe`; counterfactual pairs delen exact dezelfde finale observatie maar vereisen andere acties door de voorafgaande observaties, en noise/perturbation-varianten veranderen irrelevante velden zonder de latente temporele staat te wijzigen. Op die strengere probe haalt `neuraxon_tissue` 13/108 = 12.04%, onder random (17.59%), always-execute (16.67%) en de sequence-majority oracle-baseline (100.00%). Dit scheidt semantic-policy success expliciet van temporal/stateful Neuraxon evidence: de huidige slice bewijst een nuttige semantische adapter, maar nog geen continue-tijd/stateful/neuromodulated generalisatie.
 
 Belangrijke nuance: dit bewijst nog geen algemene Neuraxon-intelligentie. Dit bewijst dat de runtime nu een werkende semantische beslisbrug heeft voor de huidige mock-scenario's. De biologische/trinary tissue blijft daarmee instrumenteerbaar, maar de bruikbare policy komt in deze slice uit expliciete observatiesemantiek.
 
@@ -22,7 +22,7 @@ Belangrijke nuance: dit bewijst nog geen algemene Neuraxon-intelligentie. Dit be
 - Baselines: random en always-execute, elk 140 runs
 - Metrics: accuracy, confidence, per-scenario breakdown, learning curve, simple two-proportion z-tests
 - Holdout/noisy smoke benchmark: 140 deterministische varianten, 1 seed, originele scenario-type labels vervangen door `holdout_<expected_action>`; 100% semantic-policy coverage, dus niet als echte generalisatieclaim behandelen
-- Temporal dynamics probe: 6 NIA-geïnspireerde scenario's, 1 seed, finale observatie bevat geen actie-oracle; meet of eerdere observaties/state carry-over de beslissing dragen
+- Temporal dynamics benchmark: 108 NIA-geïnspireerde scenario's (6 actie-archetypes × 3 dataset-seeds × 3 sequentielengtes × counterfactual/noise-perturbation varianten), 1 tissue seed; finale observatie bevat geen actie-oracle en counterfactual pairs kunnen exact dezelfde finale probe met verschillende verwachte acties hebben
 
 ## 3. Resultaten
 
@@ -70,15 +70,18 @@ Beslissing: `needs_temporal_dynamics_evidence`. De semantic policy bridge blijft
 
 Qubic's NIA-artikelen leggen de lat anders: Vol. 1 benadrukt continue tijd en state carry-over, Vol. 2 trinary neutral/subthreshold buffering, Vol. 3 neuromodulatie en plasticity windows, Vol. 5 astrocytic/eligibility-gated plasticity, en Vol. 7 emergentie rond edge-of-chaos-dynamiek. Een one-shot finale observatie met expliciete semantische velden test dat niet.
 
-Daarom is er nu een kleine temporal dynamics probe toegevoegd. De finale observatie is overal dezelfde generieke `temporal_decision_probe`; de relevante signalen zitten alleen in de voorafgaande observaties. Resultaat:
+Daarom is de temporal dynamics benchmark nu uitgebreid. De finale observatie is overal dezelfde generieke `temporal_decision_probe`; de relevante signalen zitten alleen in de voorafgaande observaties. De dataset bevat 108 scenario's met meerdere dataset-seeds, sequentielengtes, counterfactual pairs en noise/perturbation-varianten. Resultaat:
 
 | Agent | Runs | Correct | Accuracy |
 |---|---:|---:|---:|
-| Neuraxon tissue | 6 | 1 | 16.67% |
-| Random baseline | 6 | 2 | 33.33% |
-| Always-execute baseline | 6 | 1 | 16.67% |
+| Neuraxon tissue | 108 | 13 | 12.04% |
+| Random baseline | 108 | 19 | 17.59% |
+| Always-execute baseline | 108 | 18 | 16.67% |
+| Last-observation-only baseline | 108 | 0 | 0.00% |
+| Semantic-policy-only baseline | 108 | 0 | 0.00% |
+| Sequence-majority oracle baseline | 108 | 108 | 100.00% |
 
-Interpretatie: de huidige runtime draagt nog onvoldoende taakrelevante temporele dynamiek door tot een finale probe zonder expliciete action oracle. Dat is geen regressie; het is een eerlijkere onderzoeksmeting die voorkomt dat de semantic bridge als Neuraxon-generalisatie wordt verkocht.
+Interpretatie: last-observation-only en semantic-policy-only falen volledig omdat de finale probe geen semantische actievelden bevat. De sequence-majority baseline bewijst dat de verwachte actie wel degelijk uit de voorafgaande sequentie afleidbaar is. `neuraxon_tissue` draagt die taakrelevante temporele dynamiek nog onvoldoende door tot een finale probe zonder expliciete action oracle. Dat is geen regressie; het scheidt semantic-policy success van temporal/stateful Neuraxon evidence en voorkomt dat de semantic bridge als Neuraxon-generalisatie wordt verkocht.
 
 ### Policy-ablation benchmark
 

--- a/benchmarks/results/holdout_noisy_generalization.json
+++ b/benchmarks/results/holdout_noisy_generalization.json
@@ -29,23 +29,38 @@
   "temporal_dynamics": {
     "baselines": {
       "always_execute": {
-        "run_count": 6,
-        "success_count": 1,
+        "run_count": 108,
+        "success_count": 18,
         "success_rate": 0.16666666666666666
       },
+      "last_observation_only": {
+        "run_count": 108,
+        "success_count": 0,
+        "success_rate": 0.0
+      },
       "random": {
-        "run_count": 6,
-        "success_count": 2,
-        "success_rate": 0.3333333333333333
+        "run_count": 108,
+        "success_count": 19,
+        "success_rate": 0.17592592592592593
+      },
+      "semantic_policy_only": {
+        "run_count": 108,
+        "success_count": 0,
+        "success_rate": 0.0
+      },
+      "sequence_majority": {
+        "run_count": 108,
+        "success_count": 108,
+        "success_rate": 1.0
       }
     },
-    "interpretation": "Temporal probe inspired by NIA Vol. 1/2/3/5/7: final observations hide explicit action cues, so success must come from continuous time, state carry-over, trinary buffering and modulation-like dynamics.",
+    "interpretation": "Temporal probe inspired by NIA Vol. 1/2/3/5/7: final observations hide explicit action cues, so success must come from temporal/stateful Neuraxon evidence such as continuous time, state carry-over, trinary buffering and modulation-like dynamics.",
     "neuraxon_tissue": {
-      "run_count": 6,
-      "success_count": 1,
-      "success_rate": 0.16666666666666666
+      "run_count": 108,
+      "success_count": 13,
+      "success_rate": 0.12037037037037036
     },
-    "scenario_count": 6,
+    "scenario_count": 108,
     "seed_count": 1
   }
 }

--- a/src/neuraxon_agent/holdout_generalization.py
+++ b/src/neuraxon_agent/holdout_generalization.py
@@ -7,8 +7,14 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
+from neuraxon_agent.action import AgentAction
 from neuraxon_agent.baselines import run_baseline_benchmarks
-from neuraxon_agent.benchmark import BenchmarkReport, BenchmarkScenario
+from neuraxon_agent.benchmark import (
+    BenchmarkHarness,
+    BenchmarkReport,
+    BenchmarkScenario,
+    TissueFactory,
+)
 from neuraxon_agent.scenarios import load_mock_agent_scenarios
 from neuraxon_agent.semantic_policy import SemanticTissuePolicy
 from neuraxon_agent.tissue_benchmark import TissueBenchmarkReport, run_neuraxon_tissue_benchmark
@@ -107,14 +113,16 @@ def generate_holdout_noisy_scenarios(
 
 
 def generate_temporal_dynamics_scenarios() -> list[BenchmarkScenario]:
-    """Return NIA-inspired temporal scenarios with no final action oracle.
+    """Return generated NIA-inspired temporal scenarios with no final action oracle.
 
     Qubic's NIA volumes emphasise continuous-time state, trinary neutral buffers,
     neuromodulatory context and plasticity gates. A benchmark that is solved from
-    one explicit final observation does not test those claims. These scenarios
-    therefore put the evidence in prior observations and end with an identical
-    ``temporal_decision_probe`` shape. A stateless semantic rule bridge should no
-    longer get 100%; any success must come from carried tissue/network state.
+    one explicit final observation does not test those claims. These generated
+    scenarios therefore put the evidence in prior observations and end with an
+    identical ``temporal_decision_probe`` shape. Counterfactual pairs share the
+    exact final observation while prior sequence dynamics require different
+    actions. Perturbation variants add irrelevant/noisy fields around the same
+    latent temporal state.
     """
     definitions: list[tuple[str, str, list[dict[str, Any]]]] = [
         (
@@ -166,24 +174,43 @@ def generate_temporal_dynamics_scenarios() -> list[BenchmarkScenario]:
             ],
         ),
     ]
-    return [
-        BenchmarkScenario(
-            name=f"temporal_dynamics_{name}",
-            observation_sequence=[
-                *prefix,
-                {
-                    "intent": "temporal_decision_probe",
-                    "probe": "choose_action_from_prior_dynamics",
-                    "elapsed_ticks": 1_000 + index,
-                },
-            ],
-            expected_optimal_action=expected_action,
-            difficulty=0.9,
-            scenario_type="temporal_dynamics_probe",
-            expected_actions=(expected_action,),
-        )
-        for index, (name, expected_action, prefix) in enumerate(definitions)
-    ]
+    final_probe = {
+        "intent": "temporal_decision_probe",
+        "probe": "choose_action_from_prior_dynamics",
+    }
+    scenarios: list[BenchmarkScenario] = []
+    for seed in range(3):
+        for target_length in (3, 4, 5):
+            for action_index, (name, expected_action, prefix) in enumerate(definitions):
+                expanded_prefix = _expand_temporal_prefix(
+                    prefix=prefix,
+                    expected_action=expected_action,
+                    seed=seed,
+                    target_prefix_length=target_length - 1,
+                )
+                for variant in ("counterfactual", "noise_perturbation"):
+                    scenario_prefix = [dict(observation) for observation in expanded_prefix]
+                    if variant == "noise_perturbation":
+                        scenario_prefix = _add_temporal_noise(
+                            scenario_prefix,
+                            seed=seed,
+                            action_index=action_index,
+                            target_length=target_length,
+                        )
+                    scenarios.append(
+                        BenchmarkScenario(
+                            name=(
+                                "temporal_dynamics_"
+                                f"seed{seed}_len{target_length}_{variant}_{name}"
+                            ),
+                            observation_sequence=[*scenario_prefix, dict(final_probe)],
+                            expected_optimal_action=expected_action,
+                            difficulty=0.85 + (0.03 * seed) + (0.01 * (target_length - 3)),
+                            scenario_type=f"temporal_{variant}",
+                            expected_actions=(expected_action,),
+                        )
+                    )
+    return scenarios
 
 
 def measure_semantic_policy_coverage(
@@ -236,7 +263,7 @@ def run_holdout_generalization_benchmark(
         seeds=seed_list,
         steps_per_observation=steps_per_observation,
     )
-    temporal_baselines = run_baseline_benchmarks(temporal_scenarios)
+    temporal_baselines = _run_temporal_baseline_benchmarks(temporal_scenarios)
     report = _summarize_generalization(
         tissue_report=tissue_report,
         baseline_reports=baseline_reports,
@@ -285,6 +312,148 @@ def _noisy_confidence(observation: dict[str, Any], index: int) -> float:
     return round(0.35 + ((index % 7) * 0.07), 2)
 
 
+def _expand_temporal_prefix(
+    *,
+    prefix: list[dict[str, Any]],
+    expected_action: str,
+    seed: int,
+    target_prefix_length: int,
+) -> list[dict[str, Any]]:
+    expanded = [dict(observation) for observation in prefix]
+    while len(expanded) < target_prefix_length:
+        expanded.insert(
+            -1,
+            {
+                "signal": "temporal_buffer",
+                "trinary_state": 0,
+                "subthreshold_charge": round(0.2 + (0.1 * seed), 2),
+                "latent_action_hint": expected_action,
+            },
+        )
+    return expanded[:target_prefix_length]
+
+
+def _add_temporal_noise(
+    prefix: list[dict[str, Any]],
+    *,
+    seed: int,
+    action_index: int,
+    target_length: int,
+) -> list[dict[str, Any]]:
+    noisy_prefix = [dict(observation) for observation in prefix]
+    for observation_index, observation in enumerate(noisy_prefix):
+        observation["irrelevant_sensor_drift"] = round(
+            ((seed + 1) * (action_index + 2) * (observation_index + 3)) % 17 / 100,
+            2,
+        )
+        observation["ui_noise"] = {
+            "theme": "dark" if (seed + observation_index) % 2 else "light",
+            "panel": f"panel-{target_length}-{action_index}",
+        }
+    return noisy_prefix
+
+
+class _SequenceAwareBaselineAgent:
+    def __init__(self, mode: str) -> None:
+        self._mode = mode
+        self._observations: list[dict[str, Any]] = []
+        self._think_count = 0
+        self._modulation_count = 0
+
+    def observe(self, observation: dict[str, Any]) -> None:
+        self._observations.append(observation)
+
+    def think(self, steps: int = 10) -> AgentAction:
+        del steps
+        self._think_count += 1
+        if self._mode in {"last_observation_only", "semantic_policy_only"}:
+            action = _infer_temporal_action(self._observations[-1]) or "semantic_uncovered"
+        elif self._mode == "sequence_majority":
+            action = _sequence_majority_action(self._observations)
+        else:  # pragma: no cover - defensive constructor guard
+            raise ValueError(f"unknown temporal baseline mode: {self._mode}")
+        return AgentAction(actie_type=action, confidence=1.0, raw_output=())
+
+    def modulate(self, outcome: str) -> dict[str, float]:
+        del outcome
+        self._modulation_count += 1
+        return {}
+
+    @property
+    def state(self) -> _TemporalBaselineState:
+        return _TemporalBaselineState(
+            observation_count=len(self._observations),
+            think_count=self._think_count,
+            modulation_count=self._modulation_count,
+        )
+
+
+@dataclass(frozen=True)
+class _TemporalBaselineState:
+    observation_count: int
+    think_count: int
+    modulation_count: int
+    dopamine: float = 0.0
+    serotonin: float = 0.0
+    acetylcholine: float = 0.0
+    norepinephrine: float = 0.0
+
+
+def _run_temporal_baseline_benchmarks(
+    scenarios: list[BenchmarkScenario],
+) -> dict[str, BenchmarkReport]:
+    reports = run_baseline_benchmarks(scenarios)
+    factories: dict[str, TissueFactory] = {
+        mode: _temporal_baseline_factory(mode)
+        for mode in (
+            "last_observation_only",
+            "sequence_majority",
+            "semantic_policy_only",
+        )
+    }
+    reports.update(BenchmarkHarness(steps_per_observation=1).run_agents(scenarios, factories))
+    return reports
+
+
+def _temporal_baseline_factory(mode: str) -> TissueFactory:
+    def factory() -> _SequenceAwareBaselineAgent:
+        return _SequenceAwareBaselineAgent(mode)
+
+    return factory
+
+
+def _sequence_majority_action(observations: list[dict[str, Any]]) -> str:
+    counts: dict[str, int] = {}
+    for observation in observations:
+        action = _infer_temporal_action(observation)
+        if action is not None:
+            counts[action] = counts.get(action, 0) + 1
+    if not counts:
+        return "semantic_uncovered"
+    return max(sorted(counts), key=lambda action: counts[action])
+
+
+def _infer_temporal_action(observation: dict[str, Any]) -> str | None:
+    signal = observation.get("signal")
+    if signal == "parameters_complete" and observation.get("missing_count") == 0:
+        return "execute"
+    if signal == "parameters_partial" and int(observation.get("missing_count", 0)) > 0:
+        return "query"
+    if signal == "tool_outcome":
+        failure_count = int(observation.get("failure_count", 0))
+        if failure_count >= 3 or observation.get("transient") is False:
+            return "cautious"
+        if failure_count >= 1 and observation.get("transient") is True:
+            return "retry"
+    if signal == "choice_space" and float(observation.get("ambiguity", 0.0)) >= 0.5:
+        return "explore"
+    if signal == "outcome_history" and int(observation.get("success_count", 0)) >= 3:
+        return "assertive"
+    if observation.get("risk") == "high":
+        return "cautious"
+    return None
+
+
 def _summarize_temporal_dynamics(
     *,
     temporal_report: TissueBenchmarkReport,
@@ -305,8 +474,9 @@ def _summarize_temporal_dynamics(
         },
         interpretation=(
             "Temporal probe inspired by NIA Vol. 1/2/3/5/7: final observations "
-            "hide explicit action cues, so success must come from continuous time, "
-            "state carry-over, trinary buffering and modulation-like dynamics."
+            "hide explicit action cues, so success must come from temporal/stateful "
+            "Neuraxon evidence such as continuous time, state carry-over, trinary "
+            "buffering and modulation-like dynamics."
         ),
     )
 

--- a/tests/test_benchmark_report.py
+++ b/tests/test_benchmark_report.py
@@ -71,3 +71,16 @@ def test_benchmark_report_states_policy_ablation_result() -> None:
     assert "raw-network" in report.lower() or "raw network" in report.lower()
     assert "semantic-bridge" in report.lower() or "semantic bridge" in report.lower()
     assert "policy-covered observations" in report.lower()
+
+
+def test_benchmark_report_states_expanded_temporal_dataset_and_separation() -> None:
+    report = REPORT_PATH.read_text(encoding="utf-8")
+
+    assert "108" in report
+    assert "counterfactual" in report.lower()
+    assert "noise/perturbation" in report.lower()
+    assert "last-observation-only" in report.lower()
+    assert "sequence-majority" in report.lower()
+    assert "semantic-policy-only" in report.lower()
+    assert "semantic-policy success" in report.lower()
+    assert "temporal/stateful neuraxon evidence" in report.lower()

--- a/tests/test_holdout_generalization.py
+++ b/tests/test_holdout_generalization.py
@@ -62,6 +62,7 @@ def test_temporal_dynamics_scenarios_hide_action_oracles_in_final_probe() -> Non
 
     final_observations = [scenario.observation_sequence[-1] for scenario in scenarios]
 
+    assert len(scenarios) >= 72
     assert {scenario.expected_optimal_action for scenario in scenarios} == {
         "execute",
         "query",
@@ -70,6 +71,11 @@ def test_temporal_dynamics_scenarios_hide_action_oracles_in_final_probe() -> Non
         "cautious",
         "assertive",
     }
+    assert {scenario.scenario_type for scenario in scenarios} >= {
+        "temporal_counterfactual",
+        "temporal_noise_perturbation",
+    }
+    assert {len(scenario.observation_sequence) for scenario in scenarios} >= {3, 4, 5}
     assert all(len(scenario.observation_sequence) >= 3 for scenario in scenarios)
     assert all(
         observation.get("intent") == "temporal_decision_probe"
@@ -80,6 +86,36 @@ def test_temporal_dynamics_scenarios_hide_action_oracles_in_final_probe() -> Non
     assert all("retryable" not in observation for observation in final_observations)
     assert all("known_options" not in observation for observation in final_observations)
     assert all("confidence_signal" not in observation for observation in final_observations)
+
+
+def test_temporal_dynamics_counterfactuals_require_prior_state() -> None:
+    scenarios = generate_temporal_dynamics_scenarios()
+    final_probe_groups: dict[tuple[tuple[str, object], ...], set[str]] = {}
+
+    for scenario in scenarios:
+        final_probe = tuple(sorted(scenario.observation_sequence[-1].items()))
+        final_probe_groups.setdefault(final_probe, set()).add(scenario.expected_optimal_action)
+
+    assert any(len(expected_actions) > 1 for expected_actions in final_probe_groups.values())
+
+
+def test_temporal_dynamics_summary_uses_temporal_specific_baselines() -> None:
+    report = run_holdout_generalization_benchmark(seeds=(0, 1), steps_per_observation=1)
+    temporal = report.to_dict()["temporal_dynamics"]
+
+    assert temporal["scenario_count"] >= 72
+    assert temporal["seed_count"] == 2
+    assert set(temporal["baselines"]) >= {
+        "random",
+        "always_execute",
+        "last_observation_only",
+        "sequence_majority",
+        "semantic_policy_only",
+    }
+    assert temporal["baselines"]["semantic_policy_only"]["success_rate"] == 0.0
+    assert temporal["neuraxon_tissue"]["run_count"] == temporal["scenario_count"] * 2
+    assert "semantic policy bridge result" in report.interpretation
+    assert "temporal/stateful Neuraxon evidence" in temporal["interpretation"]
 
 
 def test_semantic_tissue_beats_always_execute_on_holdout_noisy_benchmark() -> None:


### PR DESCRIPTION
## Summary
- Expands the temporal dynamics benchmark from the 6-scenario smoke probe to 108 generated scenarios across actions, dataset seeds, sequence lengths, counterfactuals, and perturbation variants.
- Adds temporal-specific baselines: last-observation-only, semantic-policy-only, and sequence-majority, so the report separates semantic-policy success from temporal/stateful Neuraxon evidence.
- Refreshes `benchmarks/results/holdout_noisy_generalization.json` and updates the benchmark report with the larger temporal dataset results.

## Verification
- `uv run pytest tests/test_holdout_generalization.py tests/test_benchmark_report.py -q` -> 14 passed
- `uv run ruff check src/neuraxon_agent/holdout_generalization.py tests/test_holdout_generalization.py tests/test_benchmark_report.py` -> passed
- `uv run mypy src/neuraxon_agent/holdout_generalization.py` -> passed
- `uv run pytest -q` -> 184 passed, 3 pre-existing warnings from `scripts/smoke_test.py` returning bool
- `uv run ruff check .` -> pre-existing lint failures outside the changed files, mostly vendor/smoke/memory/modulation files
- `uv run mypy src tests` -> pre-existing typing failures outside this slice, mostly vendor modules and existing strict typing gaps

Closes #51
