### PR TITLE
docs: gate deferred roadmap work

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,28 @@ PYTHONPATH=src python -m pytest tests/ -v
 ## Status
 
 Dit project is in actieve ontwikkeling. Zie de [GitHub issues](https://github.com/sisutuulenisa/neuraxon-hybrid/issues) voor de roadmap.
+
+## Roadmap gate
+
+Current phase: benchmark the decision layer before expanding input/state complexity.
+The current benchmark report shows useful semantic routing and an explicit
+`temporal_context_bridge`, but raw Neuraxon dynamics have not yet demonstrated a
+learned policy that generalizes meaningfully above baselines. The near-term
+blockers and prerequisite evidence are tracked in:
+
+- #51 — expanded temporal benchmark beyond the original smoke probe.
+- #52 — policy-ablation separating semantic-bridge behavior from raw-network behavior.
+- #53 — temporal state carry-over into action decisions.
+- #54 — criticality and neuromodulator dynamics instrumentation.
+- #55 — this roadmap gate and documentation/linking pass.
+
+Minimum evidence before deferred work resumes:
+
+- Memory persistence remains deferred until temporal benchmark performance is
+  meaningfully above baselines and the useful behavior survives raw/adapter
+  separation, so persisted state would preserve real decision value rather than
+  semantic routing artifacts.
+- Visual perception remains deferred until the base decision layer generalizes
+  beyond hand-authored semantic routing. Additional screenshots, DOM grids, or
+  multi-sphere visual inputs should not be added before the core policy can make
+  useful non-visual decisions under temporal/stateful evaluation.

--- a/tests/test_roadmap_gate_docs.py
+++ b/tests/test_roadmap_gate_docs.py
@@ -1,0 +1,32 @@
+"""Tests for roadmap gate documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+README_PATH = Path("README.md")
+
+
+def test_readme_documents_current_benchmark_gate_for_deferred_work() -> None:
+    readme = README_PATH.read_text(encoding="utf-8")
+    lower = readme.lower()
+
+    required_phrases = [
+        "## roadmap gate",
+        "current phase",
+        "temporal benchmark",
+        "policy-ablation",
+        "criticality",
+        "memory persistence remains deferred",
+        "visual perception remains deferred",
+        "#51",
+        "#52",
+        "#53",
+        "#54",
+        "#55",
+    ]
+    for phrase in required_phrases:
+        assert phrase in lower
+
+    assert "meaningfully above baselines" in lower
+    assert "beyond hand-authored semantic routing" in lower


### PR DESCRIPTION
Closes #55

Summary:
- Add an explicit README roadmap gate for the current benchmark phase.
- Keep memory persistence deferred until temporal benchmark performance is meaningfully above baselines and survives raw/adapter separation.
- Keep visual perception deferred until the base decision layer generalizes beyond hand-authored semantic routing.
- Add a content-contract test so the gate and prerequisite issue links stay documented.

Verification:
- `uv run --extra dev pytest tests/test_roadmap_gate_docs.py -q` ✅
- `uv run --extra dev pytest tests/test_benchmark_report.py tests/test_roadmap_gate_docs.py -q` ✅
- `uv run --extra dev pytest -q` ✅ (189 passed, 3 pre-existing smoke-test warnings)
- `uv run --extra dev ruff check tests/test_roadmap_gate_docs.py` ✅
- Verified #34 and #35 already contain roadmap-gate comments linking #51, #52, #53, #54, and #55.

Notes:
- Full `uv run --extra dev ruff check .` and `uv run --extra dev mypy src/` still fail on pre-existing vendor/script/type issues unrelated to this documentation slice.
