### PR TITLE
feat: add persistent tissue checkpoints

### DIFF
--- a/src/neuraxon_agent/__init__.py
+++ b/src/neuraxon_agent/__init__.py
@@ -52,7 +52,7 @@ from neuraxon_agent.holdout_generalization import (
 from neuraxon_agent.memory import Memory
 from neuraxon_agent.modulation import Modulation
 from neuraxon_agent.perception import PerceptionEncoder
-from neuraxon_agent.persistence import load_state, save_state
+from neuraxon_agent.persistence import PersistentAgentTissue, load_state, save_state
 from neuraxon_agent.scenarios import MOCK_AGENT_ACTIONS, load_mock_agent_scenarios
 from neuraxon_agent.semantic_policy import SemanticTissuePolicy
 from neuraxon_agent.streaming import StreamEvent, StreamingLoop
@@ -74,6 +74,7 @@ __all__ = [
     "benchmark_action_coverage",
     "normalize_benchmark_action",
     "AgentTissue",
+    "PersistentAgentTissue",
     "TissueState",
     "Modulation",
     "Memory",

--- a/src/neuraxon_agent/persistence.py
+++ b/src/neuraxon_agent/persistence.py
@@ -2,30 +2,27 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
-from typing import Any
 
+from neuraxon_agent.action import AgentAction
 from neuraxon_agent.tissue import AgentTissue
-from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters, load_network
+
+DEFAULT_AUTO_SAVE_TRIGGERS = frozenset({"modulate", "store_experience", "shutdown"})
 
 
 def save_state(tissue: AgentTissue, path: str) -> None:
     """Save tissue state plus metadata to a JSON file."""
-    data = {
-        "version": 1,
-        "params": {
-            "num_input_neurons": tissue.params.num_input_neurons,
-            "num_hidden_neurons": tissue.params.num_hidden_neurons,
-            "num_output_neurons": tissue.params.num_output_neurons,
-        },
-        "network": tissue.network.to_dict(),
-    }
-    Path(path).write_text(json.dumps(data, indent=2))
+    tissue.save(path)
 
 
 def load_state(path: str) -> AgentTissue:
     """Load tissue state from a JSON file."""
     data = json.loads(Path(path).read_text())
+    if "network" not in data:
+        return AgentTissue.load(path)
+
     p = data.get("params", {})
     params = NetworkParameters(
         num_input_neurons=p.get("num_input_neurons", 5),
@@ -33,5 +30,119 @@ def load_state(path: str) -> AgentTissue:
         num_output_neurons=p.get("num_output_neurons", 5),
     )
     tissue = AgentTissue(params)
-    # Network state restoration is limited by upstream API
+    tmp = Path(path).with_suffix(Path(path).suffix + ".network.tmp")
+    try:
+        tmp.write_text(json.dumps(data["network"]), encoding="utf-8")
+        tissue.network = load_network(str(tmp))
+    finally:
+        tmp.unlink(missing_ok=True)
     return tissue
+
+
+class PersistentAgentTissue(AgentTissue):
+    """AgentTissue with automatic, rotating checkpoint persistence."""
+
+    def __init__(
+        self,
+        params: NetworkParameters | None = None,
+        *,
+        save_dir: str | Path = "~/.neuraxon",
+        auto_save: bool = True,
+        auto_save_triggers: set[str] | None = None,
+        keep_last: int = 5,
+    ) -> None:
+        super().__init__(params)
+        self.save_dir = Path(save_dir).expanduser()
+        self.save_dir.mkdir(parents=True, exist_ok=True)
+        self.auto_save = auto_save
+        self.auto_save_triggers = set(auto_save_triggers or DEFAULT_AUTO_SAVE_TRIGGERS)
+        self.keep_last = max(1, keep_last)
+        self._checkpoint_counter = self._discover_checkpoint_counter()
+
+    def think(self, steps: int = 10) -> AgentAction:
+        """Run inference and optionally checkpoint after thinking."""
+        action = super().think(steps)
+        self._maybe_checkpoint("think")
+        return action
+
+    def modulate(self, outcome: str) -> dict[str, float]:
+        """Apply feedback and optionally checkpoint the learned state."""
+        result = super().modulate(outcome)
+        self._maybe_checkpoint("modulate")
+        return result
+
+    def store_experience(self, action: AgentAction, outcome: str) -> str:
+        """Store an experience and optionally checkpoint the updated memory."""
+        experience_id = super().store_experience(action, outcome)
+        self._maybe_checkpoint("store_experience")
+        return experience_id
+
+    def shutdown(self) -> None:
+        """Persist an explicit shutdown checkpoint when configured."""
+        self._maybe_checkpoint("shutdown")
+
+    def load_latest(self) -> bool:
+        """Load the most recent checkpoint into this instance."""
+        latest = self._latest_checkpoint()
+        if latest is None:
+            return False
+
+        loaded = AgentTissue.load(str(latest))
+        self.params = loaded.params
+        self.network = loaded.network
+        self.encoder = loaded.encoder
+        self.decoder = loaded.decoder
+        self.semantic_policy_enabled = loaded.semantic_policy_enabled
+        self.semantic_policy = loaded.semantic_policy
+        self.last_action_source = loaded.last_action_source
+        self.last_raw_decoder_action = loaded.last_raw_decoder_action
+        self._last_observation = loaded._last_observation
+        self._temporal_context = loaded._temporal_context
+        self._feedback = loaded.feedback
+        self.memory = loaded.memory
+        self._checkpoint_counter = self._discover_checkpoint_counter()
+        return True
+
+    def _maybe_checkpoint(self, trigger: str) -> Path | None:
+        if not self.auto_save or trigger not in self.auto_save_triggers:
+            return None
+        return self._checkpoint()
+
+    def _checkpoint(self) -> Path:
+        self._checkpoint_counter += 1
+        tmp = self.save_dir / f"checkpoint_{self._checkpoint_counter:06d}.json.tmp"
+        final = self.save_dir / f"checkpoint_{self._checkpoint_counter:06d}.json"
+        self.save(str(tmp))
+        os.replace(tmp, final)
+        self._rotate_checkpoints()
+        return final
+
+    def _rotate_checkpoints(self) -> None:
+        checkpoints = self._checkpoint_files()
+        for stale in checkpoints[:-self.keep_last]:
+            memory_path = self._memory_path_for_checkpoint(stale)
+            stale.unlink(missing_ok=True)
+            memory_path.unlink(missing_ok=True)
+
+    def _latest_checkpoint(self) -> Path | None:
+        checkpoints = self._checkpoint_files()
+        return checkpoints[-1] if checkpoints else None
+
+    def _checkpoint_files(self) -> list[Path]:
+        return sorted(
+            path for path in self.save_dir.glob("checkpoint_*.json")
+            if path.stem.rsplit("_", 1)[-1].isdigit()
+        )
+
+    def _discover_checkpoint_counter(self) -> int:
+        latest = self._latest_checkpoint()
+        if latest is None:
+            return 0
+        try:
+            return int(latest.stem.rsplit("_", 1)[1])
+        except (IndexError, ValueError):
+            return 0
+
+    @staticmethod
+    def _memory_path_for_checkpoint(checkpoint: Path) -> Path:
+        return Path(str(checkpoint) + ".memory.json")

--- a/src/neuraxon_agent/tissue.py
+++ b/src/neuraxon_agent/tissue.py
@@ -13,7 +13,7 @@ from neuraxon_agent.modulation import ModulationFeedback
 from neuraxon_agent.perception import PerceptionEncoder
 from neuraxon_agent.semantic_policy import SemanticTissuePolicy
 from neuraxon_agent.temporal_context import TemporalContextBuffer
-from neuraxon_agent.vendor.neuraxon2 import NetworkParameters, NeuraxonNetwork
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters, NeuraxonNetwork, load_network
 
 
 @dataclass
@@ -137,7 +137,7 @@ class AgentTissue:
             num_output_neurons=params_data.get("num_output_neurons", 5),
         )
         instance = cls(params)
-        # TODO: restore full network state from dict when upstream supports from_dict
+        instance.network = load_network(path)
         # Restore memory if saved alongside
         memory_path = data.pop("_memory_path", None)
         if memory_path and Path(memory_path).exists():

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,126 @@
+"""Tests for automatic tissue persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from neuraxon_agent import AgentTissue, PersistentAgentTissue
+from neuraxon_agent.persistence import load_state, save_state
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
+
+
+def small_params() -> NetworkParameters:
+    return NetworkParameters(num_input_neurons=3, num_hidden_neurons=5, num_output_neurons=2)
+
+
+def test_agent_tissue_load_restores_network_runtime_state(tmp_path: Path) -> None:
+    tissue = AgentTissue(small_params(), semantic_policy_enabled=False)
+    tissue.observe({"tool_result": "success"})
+    tissue.think(steps=3)
+    tissue.modulate("success")
+    before_state = tissue.state
+    path = tmp_path / "state.json"
+
+    tissue.save(str(path))
+    loaded = AgentTissue.load(str(path))
+
+    assert loaded.state.step_count == before_state.step_count
+    assert loaded.state.energy == before_state.energy
+    assert loaded.state.dopamine == before_state.dopamine
+    assert loaded.network.get_output_states() == tissue.network.get_output_states()
+
+
+def test_save_state_load_state_preserves_network_and_memory(tmp_path: Path) -> None:
+    tissue = AgentTissue(small_params(), semantic_policy_enabled=False)
+    tissue.observe({"tool_result": "success"})
+    action = tissue.think(steps=3)
+    tissue.store_experience(action, "success")
+    path = tmp_path / "state.json"
+
+    save_state(tissue, str(path))
+    loaded = load_state(str(path))
+
+    assert loaded.state.step_count == tissue.state.step_count
+    assert len(loaded.memory) == 1
+    assert loaded.recall_similar({"tool_result": "success"})[0].outcome == "success"
+
+
+def test_persistent_tissue_checkpoints_after_configured_trigger(tmp_path: Path) -> None:
+    tissue = PersistentAgentTissue(
+        small_params(),
+        save_dir=tmp_path,
+        auto_save=True,
+        auto_save_triggers={"modulate"},
+    )
+    tissue.observe({"tool_result": "success"})
+    tissue.think(steps=1)
+
+    assert list(tmp_path.glob("checkpoint_*.json")) == []
+    tissue.modulate("success")
+
+    checkpoints = sorted(
+        path for path in tmp_path.glob("checkpoint_*.json")
+        if path.stem.rsplit("_", 1)[-1].isdigit()
+    )
+    assert [p.name for p in checkpoints] == ["checkpoint_000001.json"]
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_persistent_tissue_checkpoint_rotation_keeps_latest(tmp_path: Path) -> None:
+    tissue = PersistentAgentTissue(
+        small_params(),
+        save_dir=tmp_path,
+        auto_save=True,
+        auto_save_triggers={"modulate"},
+        keep_last=2,
+    )
+    tissue.observe({"tool_result": "success"})
+    tissue.think(steps=1)
+
+    for _ in range(4):
+        tissue.modulate("success")
+
+    checkpoints = sorted(
+        path for path in tmp_path.glob("checkpoint_*.json")
+        if path.stem.rsplit("_", 1)[-1].isdigit()
+    )
+    assert [p.name for p in checkpoints] == [
+        "checkpoint_000003.json",
+        "checkpoint_000004.json",
+    ]
+    assert not (tmp_path / "checkpoint_000001.json.memory.json").exists()
+
+
+def test_persistent_tissue_load_latest_restores_most_recent_checkpoint(tmp_path: Path) -> None:
+    tissue = PersistentAgentTissue(
+        small_params(),
+        save_dir=tmp_path,
+        auto_save=True,
+        auto_save_triggers={"modulate", "store_experience"},
+    )
+    tissue.observe({"tool_result": "success"})
+    action = tissue.think(steps=2)
+    tissue.store_experience(action, "success")
+    tissue.modulate("success")
+
+    rehydrated = PersistentAgentTissue(small_params(), save_dir=tmp_path, auto_save=False)
+    assert rehydrated.load_latest() is True
+
+    assert rehydrated.state.step_count == tissue.state.step_count
+    assert rehydrated.state.dopamine == tissue.state.dopamine
+    assert len(rehydrated.memory) == 1
+
+
+def test_persistent_tissue_shutdown_checkpoint_is_explicit(tmp_path: Path) -> None:
+    tissue = PersistentAgentTissue(
+        small_params(),
+        save_dir=tmp_path,
+        auto_save=True,
+        auto_save_triggers={"shutdown"},
+    )
+    tissue.observe({"tool_result": "success"})
+    tissue.think(steps=1)
+
+    tissue.shutdown()
+
+    assert (tmp_path / "checkpoint_000001.json").exists()


### PR DESCRIPTION
Closes #35

Summary:
- Adds `PersistentAgentTissue` with configurable auto-save triggers for `modulate`, `think`, `store_experience`, and explicit `shutdown` checkpoints.
- Writes checkpoints via temporary files plus atomic rename, keeps rotating checkpoint retention, and can hydrate the latest checkpoint.
- Reuses upstream `load_network()` in `AgentTissue.load()` and `load_state()` so network runtime state survives restart instead of only restoring params/memory.

Verification:
- `uv run --extra dev pytest tests/test_persistence.py -q` ✅
- `uv run --extra dev ruff check src/neuraxon_agent/__init__.py src/neuraxon_agent/persistence.py src/neuraxon_agent/tissue.py tests/test_persistence.py` ✅
- `uv run --extra dev mypy src/neuraxon_agent/persistence.py src/neuraxon_agent/tissue.py tests/test_persistence.py` ✅
- `uv run --extra dev pytest tests/ -q` ✅
- `git diff --check` ✅

Notes:
- Live issue body and comments were reviewed first. The roadmap gate prerequisites #51-#55 are now closed, so this implements the bounded Phase 1 auto-save foundation plus the smallest safe full-state restoration fix needed for restart roundtrips.
- Full multi-session merge, experience replay, and structural migration remain outside this bounded phase.
