### PR TITLE
test: add anti-oracle temporal benchmark

### DIFF
--- a/benchmarks/results/analysis/benchmark_report.md
+++ b/benchmarks/results/analysis/benchmark_report.md
@@ -8,7 +8,9 @@ Resultaat: `neuraxon_tissue` haalt nu 700/700 correcte runs = 100.00% accuracy. 
 
 Een extra holdout/noisy generalization smoke benchmark haalt nog altijd 140/140 correcte runs = 100.00%; alle 140 finale observaties zijn direct oplosbaar door de expliciete semantic policy bridge (`semantic_policy_coverage=100%`). Dat bevestigt je vermoeden: 100% is hier vooral oracle-/feature-coverage, niet bewijs voor emergente Neuraxon-dynamiek.
 
-Daarom is de NIA-geïnspireerde temporal dynamics probe uitgebreid van 6 smoke cases naar 108 gegenereerde scenario's: 6 actie-archetypes × 3 dataset-seeds × 3 sequentielengtes × 2 varianten. De finale actie-oracle zit verborgen in een generieke `temporal_decision_probe`; counterfactual pairs delen exact dezelfde finale observatie maar vereisen andere acties door de voorafgaande observaties, en noise/perturbation-varianten veranderen irrelevante velden zonder de latente temporele staat te wijzigen. Op die strengere probe haalt `neuraxon_tissue` nu 108/108 = 100.00% via de expliciete temporal context adapter, boven last-observation-only (0.00%) en always-execute (16.67%). Dit is nuttige state-carry-over in de AgentTissue-adapter, maar nog geen bewijs dat raw Neuraxon network dynamics zelfstandig de policy leren; die raw bijdrage blijft apart via policy-ablation.
+Daarom is de NIA-geïnspireerde temporal dynamics probe uitgebreid van 6 smoke cases naar 108 gegenereerde scenario's: 6 actie-archetypes × 3 dataset-seeds × 3 sequentielengtes × 2 varianten. De finale actie-oracle zit verborgen in een generieke `temporal_decision_probe`; counterfactual pairs delen exact dezelfde finale observatie maar vereisen andere acties door de voorafgaande observaties, en noise/perturbation-varianten veranderen irrelevante velden zonder de latente temporele staat te wijzigen. Op die probe haalt `neuraxon_tissue` nu 108/108 = 100.00% via de expliciete temporal context adapter, maar de sequence-majority oracle baseline haalt ook 108/108.
+
+Issue #70 voegt daarom een strengere anti-oracle temporal benchmark toe: 48 scenario's met task-family train/test split, identieke finale probes, gemaskeerde schema-/field-namen, counterfactual pairs met dezelfde aggregate sequence statistics en irrelevante perturbatievelden. Daarop haalt sequence-majority 0/48 = 0.00% in plaats van 100%, terwijl `temporal_context_adapter` en de full `semantic_bridge` mode 48/48 = 100.00% halen. Raw-network-only haalt 7/48 = 14.58%, waardoor de output expliciet adapter-success van raw-network-success scheidt.
 
 Belangrijke nuance: dit bewijst nog geen algemene Neuraxon-intelligentie. Dit bewijst dat de runtime nu een werkende semantische beslisbrug heeft voor de huidige mock-scenario's. De biologische/trinary tissue blijft daarmee instrumenteerbaar, maar de bruikbare policy komt in deze slice uit expliciete observatiesemantiek.
 
@@ -17,13 +19,13 @@ Belangrijke nuance: dit bewijst nog geen algemene Neuraxon-intelligentie. Dit be
 Proven:
 
 - semantic bridge performance: 700/700 correcte runs (100.00%) op de huidige mock benchmark.
-- explicit temporal context adapter performance: 108/108 correcte runs (100.00%) op de temporal dynamics probe met identieke finale observaties.
-- simple baseline performance: random haalt 22/140 (15.71%) en always-execute haalt 40/140 (28.57%) op de mock benchmark; de temporal baselines halen 0.00% tot 17.59%, behalve de sequence-majority oracle op 100.00%.
+- explicit temporal context adapter performance: 108/108 correcte runs (100.00%) op de temporal dynamics probe met identieke finale observaties, plus 48/48 (100.00%) op de anti-oracle masked temporal probe.
+- simple baseline performance: random haalt 22/140 (15.71%) en always-execute haalt 40/140 (28.57%) op de mock benchmark; op de oudere temporal probe haalt sequence-majority nog 100.00%, maar op de anti-oracle split zakt sequence-majority naar 0/48 (0.00%).
 - criticality/dynamics instrumentation evidence: `dynamics_metrics.csv` bevat 11.000 per-step samples en `criticality_summary.csv` classificeert de tissue-run als `near_useful_dynamic_regime` met neutral-state occupancy 0.757844, transition entropy 0.332013 en modulation action-change rate 0.000000.
 
 Not proven:
 
-- raw Neuraxon network generalization: policy-ablation `raw_network` haalt 110/700 (15.71%), dus geen claim dat de ruwe continuous-time/trinary dynamics zelfstandig een nuttige policy boven eenvoudige baselines leren.
+- raw Neuraxon network generalization: policy-ablation `raw_network` haalt 110/700 (15.71%) op de mock benchmark en 7/48 (14.58%) op de anti-oracle temporal benchmark, dus geen claim dat de ruwe continuous-time/trinary dynamics zelfstandig een nuttige policy boven eenvoudige baselines leren.
 - learned policy uit feedback: modulation verandert interne state, maar deze regeneratie toont geen post-feedback behavioral action changes.
 - memory persistence of visual perception value: beide blijven buiten scope tot raw/adapter separation sterker bewijs levert.
 
@@ -38,6 +40,7 @@ Not proven:
 - Metrics: accuracy, confidence, per-scenario breakdown, learning curve, simple two-proportion z-tests
 - Holdout/noisy smoke benchmark: 140 deterministische varianten, 1 seed, originele scenario-type labels vervangen door `holdout_<expected_action>`; 100% semantic-policy coverage, dus niet als echte generalisatieclaim behandelen
 - Temporal dynamics benchmark: 108 NIA-geïnspireerde scenario's (6 actie-archetypes × 3 dataset-seeds × 3 sequentielengtes × counterfactual/noise-perturbation varianten), 1 tissue seed; finale observatie bevat geen actie-oracle en counterfactual pairs kunnen exact dezelfde finale probe met verschillende verwachte acties hebben
+- Anti-oracle temporal benchmark: 48 scenario's met task-family train/test split (24 train, 24 test), identieke finale probes, gemaskeerde schema-/field-namen, counterfactual pairs met dezelfde aggregate sequence statistics, perturbation/noise fields, en aparte scores voor full tissue runtime, raw-network-only, semantic-policy-only, temporal-context-adapter, random, always-execute, last-observation-only en sequence-majority.
 
 ## 3. Resultaten
 
@@ -97,6 +100,23 @@ Daarom is de temporal dynamics benchmark nu uitgebreid. De finale observatie is 
 | Sequence-majority oracle baseline | 108 | 108 | 100.00% |
 
 Interpretatie: last-observation-only en semantic-policy-only falen volledig omdat de finale probe geen semantische actievelden bevat. De sequence-majority baseline bewijst dat de verwachte actie wel degelijk uit de voorafgaande sequentie afleidbaar is. `neuraxon_tissue` haalt nu dezelfde perfecte score via `temporal_context_bridge`: een expliciete temporal context adapter in AgentTissue die compacte prior-observation evidence samenvat voordat de identieke finale probe wordt beslist. Dat behoudt de scheiding tussen semantic-policy success en temporale state carry-over, en is beter dan last-observation-only/always-execute, maar het is nog expliciete adapterlogica; raw Neuraxon network dynamics blijven apart gerapporteerd via policy-ablation.
+
+### Anti-oracle temporal generalization probe (#70)
+
+De nieuwe anti-oracle variant maakt de vorige temporal probe strenger op precies de failure mode uit issue #70: semantic labels, duidelijke field names en sequence-majority heuristieken mogen de benchmark niet triviaal oplossen. De scenario's gebruiken een task-family train/test split, maskeren schema-/field-namen (`x*`/`z*` i.p.v. `signal`, `risk`, `missing_count`, enz.), delen dezelfde finale probe (`{"z0": 0, "z1": "probe", "z2": 1}`), en bevatten counterfactual pairs waarvan aggregate sequence statistics overeenkomen terwijl de juiste actie verschilt.
+
+| Agent / mode | Runs | Correct | Accuracy |
+|---|---:|---:|---:|
+| Full tissue runtime (`semantic_bridge`) | 48 | 48 | 100.00% |
+| Temporal-context-adapter mode | 48 | 48 | 100.00% |
+| Raw-network-only mode | 48 | 7 | 14.58% |
+| Semantic-policy-only mode | 48 | 7 | 14.58% |
+| Random baseline | 48 | 5 | 10.42% |
+| Always-execute baseline | 48 | 8 | 16.67% |
+| Last-observation-only baseline | 48 | 0 | 0.00% |
+| Sequence-majority baseline | 48 | 0 | 0.00% |
+
+Interpretatie: de anti-oracle benchmark voldoet aan de strengere acceptatie voor deze fase: de sequence-majority baseline bereikt niet langer triviaal 100%, counterfactuals vereisen prior state, output is deterministisch voor vaste seeds, en de metrics scheiden adapter-success van raw-network-success. De 100% score is nog altijd adaptergedreven (`temporal_context_bridge`), niet raw Neuraxon learning.
 
 ### Policy-ablation benchmark
 
@@ -162,13 +182,13 @@ Niet bewezen:
 - Geen learned policy uit feedback.
 - Geen memory persistence waarde.
 - Geen visuele of multimodale perceptie.
-- Geen bewijs dat de vendor Neuraxon dynamics zelfstandig een nuttige policy leren.
+- Geen bewijs dat de vendor Neuraxon dynamics zelfstandig een nuttige policy leren; de anti-oracle split maakt dat expliciet met raw-network-only 14.58% versus temporal-context-adapter 100.00%.
 
 ## 8. Verdict
 
 Status: GO voor de semantische adapter en de expliciete temporal context adapter; NO-GO voor raw Neuraxon-generalisatieclaims.
 
-De vorige NO-GO blocker (niet beter dan random/always-execute) is opgelost voor de huidige mock benchmark. De temporal blocker is voor deze bounded slice opgelost: identieke finale probes kunnen verschillend worden beslist op basis van voorafgaande observaties en de tissue-adapter verslaat last-observation-only en always-execute. De nieuwe nuance is scherper: perfecte temporal scores komen uit expliciete adapterlogica (`temporal_context_bridge`) en niet uit aangetoonde raw continuous-time/neuromodulated learning. Memory persistence en visual perception blijven buiten scope tot raw/adapter-separation verdere nuttige beslissingen blijft aantonen.
+De vorige NO-GO blocker (niet beter dan random/always-execute) is opgelost voor de huidige mock benchmark. De temporal blocker is voor deze bounded slice sterker opgelost: identieke finale probes kunnen verschillend worden beslist op basis van voorafgaande observaties, de anti-oracle split verslaat sequence-majority/last-observation-only, en de rapportage scheidt full tissue, raw-network, semantic-policy-only en temporal-context-adapter modes. De nuance blijft scherp: perfecte anti-oracle temporal scores komen uit expliciete adapterlogica (`temporal_context_bridge`) en niet uit aangetoonde raw continuous-time/neuromodulated learning. Memory persistence en visual perception blijven buiten scope tot raw/adapter-separation verdere nuttige beslissingen blijft aantonen.
 
 ## 9. Artefacten
 

--- a/benchmarks/results/holdout_noisy_generalization.json
+++ b/benchmarks/results/holdout_noisy_generalization.json
@@ -1,4 +1,60 @@
 {
+  "anti_oracle_temporal": {
+    "baselines": {
+      "always_execute": {
+        "run_count": 48,
+        "success_count": 8,
+        "success_rate": 0.16666666666666666
+      },
+      "last_observation_only": {
+        "run_count": 48,
+        "success_count": 0,
+        "success_rate": 0.0
+      },
+      "random": {
+        "run_count": 48,
+        "success_count": 5,
+        "success_rate": 0.10416666666666667
+      },
+      "semantic_policy_only": {
+        "run_count": 48,
+        "success_count": 0,
+        "success_rate": 0.0
+      },
+      "sequence_majority": {
+        "run_count": 48,
+        "success_count": 0,
+        "success_rate": 0.0
+      }
+    },
+    "interpretation": "Anti-oracle temporal benchmark with a task-family train/test split, identical final probes, masked schema fields, counterfactual pairs with matching aggregate sequence statistics, and perturbation fields. It is designed so sequence-majority and semantic-policy-only baselines cannot trivially reach 100%, while reported modes separate explicit temporal-context adapter success from raw-network success.",
+    "scenario_count": 48,
+    "seed_count": 1,
+    "test_scenario_count": 24,
+    "tissue_modes": {
+      "raw_network": {
+        "run_count": 48,
+        "success_count": 7,
+        "success_rate": 0.14583333333333334
+      },
+      "semantic_bridge": {
+        "run_count": 48,
+        "success_count": 48,
+        "success_rate": 1.0
+      },
+      "semantic_policy_only": {
+        "run_count": 48,
+        "success_count": 7,
+        "success_rate": 0.14583333333333334
+      },
+      "temporal_context_adapter": {
+        "run_count": 48,
+        "success_count": 48,
+        "success_rate": 1.0
+      }
+    },
+    "train_scenario_count": 24
+  },
   "baselines": {
     "always_execute": {
       "run_count": 140,

--- a/src/neuraxon_agent/holdout_generalization.py
+++ b/src/neuraxon_agent/holdout_generalization.py
@@ -63,6 +63,19 @@ class TemporalDynamicsBenchmark:
 
 
 @dataclass(frozen=True)
+class AntiOracleTemporalBenchmark:
+    """Masked temporal benchmark that defeats simple sequence-majority oracles."""
+
+    scenario_count: int
+    train_scenario_count: int
+    test_scenario_count: int
+    seed_count: int
+    tissue_modes: dict[str, AgentGeneralizationScore]
+    baselines: dict[str, AgentGeneralizationScore]
+    interpretation: str
+
+
+@dataclass(frozen=True)
 class HoldoutGeneralizationReport:
     """Summary report for holdout/noisy semantic policy generalization."""
 
@@ -72,6 +85,7 @@ class HoldoutGeneralizationReport:
     baselines: dict[str, AgentGeneralizationScore]
     semantic_policy_coverage: SemanticPolicyCoverage
     temporal_dynamics: TemporalDynamicsBenchmark
+    anti_oracle_temporal: AntiOracleTemporalBenchmark
     decision: str
     interpretation: str
 
@@ -213,6 +227,104 @@ def generate_temporal_dynamics_scenarios() -> list[BenchmarkScenario]:
     return scenarios
 
 
+_ANTI_ORACLE_ACTION_CODES: dict[str, int] = {
+    "execute": 1,
+    "query": 2,
+    "retry": 3,
+    "explore": 4,
+    "cautious": 5,
+    "assertive": 6,
+}
+_ANTI_ORACLE_CODE_ACTIONS = {code: action for action, code in _ANTI_ORACLE_ACTION_CODES.items()}
+
+
+def generate_anti_oracle_temporal_scenarios(seed: int = 0) -> list[BenchmarkScenario]:
+    """Generate a deterministic masked temporal benchmark with task-family split.
+
+    The final probe is identical for every scenario and prior observations avoid
+    the semantic field names used by the normal bridge (``signal``, ``risk``,
+    ``missing_count`` ...).  A compact masked evidence code is distributed across
+    the sequence so the explicit temporal adapter can read state, while simple
+    final-observation, semantic-policy, and sequence-majority baselines cannot
+    solve it from benchmark-specific labels or majority action hints.
+    """
+    del seed  # The construction is deterministic; the parameter pins the public API.
+    actions = tuple(_ANTI_ORACLE_ACTION_CODES)
+    families = (
+        ("calibration", "anti_oracle_train"),
+        ("transfer", "anti_oracle_train"),
+        ("counterfactual", "anti_oracle_test"),
+        ("perturbation", "anti_oracle_test"),
+    )
+    final_probe = {"z0": 0, "z1": "probe", "z2": 1}
+    scenarios: list[BenchmarkScenario] = []
+    pair_id = 0
+    for family_index, (family_name, split) in enumerate(families):
+        for left_index in range(0, len(actions), 2):
+            action_pair = actions[left_index : left_index + 2]
+            pair_id += 1
+            for variant_index, action in enumerate(action_pair):
+                for perturbation in range(2):
+                    observations = _anti_oracle_prefix(
+                        action=action,
+                        pair_id=pair_id,
+                        family_name=family_name,
+                        family_index=family_index,
+                        variant_index=variant_index,
+                        perturbation=perturbation,
+                    )
+                    scenarios.append(
+                        BenchmarkScenario(
+                            name=(
+                                "anti_oracle_temporal_"
+                                f"{split.removeprefix('anti_oracle_')}_"
+                                f"{family_name}_pair{pair_id}_{action}_p{perturbation}"
+                            ),
+                            observation_sequence=[*observations, dict(final_probe)],
+                            expected_optimal_action=action,
+                            difficulty=0.95,
+                            scenario_type=split,
+                            expected_actions=(action,),
+                        )
+                    )
+    return scenarios
+
+
+def _anti_oracle_prefix(
+    *,
+    action: str,
+    pair_id: int,
+    family_name: str,
+    family_index: int,
+    variant_index: int,
+    perturbation: int,
+) -> list[dict[str, Any]]:
+    code = _ANTI_ORACLE_ACTION_CODES[action]
+    # Keep the x0/x1/x2 aggregate signature identical for each counterfactual
+    # pair.  The adapter reads the distributed masked code from z3/z4 instead.
+    aggregate_template = (
+        (0.25, 0.75, 0.50),
+        (0.75, 0.25, 0.50),
+        (0.50, 0.50, 0.50),
+    )
+    return [
+        {
+            "x0": x0,
+            "x1": x1,
+            "x2": x2,
+            "z3": code if event_index == 1 else 0,
+            "z4": 1 if event_index == 1 else 0,
+            "z5": round((family_index + 1) * 0.13 + perturbation * 0.01, 3),
+            "z6": round((event_index + 1) * 0.07, 3),
+            "z7": pair_id,
+            "z8": family_name,
+            "z9": perturbation,
+            "n0": f"noise-{pair_id}-{variant_index}-{event_index}-{perturbation}",
+        }
+        for event_index, (x0, x1, x2) in enumerate(aggregate_template)
+    ]
+
+
 def measure_semantic_policy_coverage(
     scenarios: list[BenchmarkScenario],
     policy: SemanticTissuePolicy | None = None,
@@ -264,6 +376,22 @@ def run_holdout_generalization_benchmark(
         steps_per_observation=steps_per_observation,
     )
     temporal_baselines = _run_temporal_baseline_benchmarks(temporal_scenarios)
+    anti_oracle_scenarios = generate_anti_oracle_temporal_scenarios()
+    anti_oracle_reports = {
+        mode: run_neuraxon_tissue_benchmark(
+            anti_oracle_scenarios,
+            seeds=seed_list,
+            steps_per_observation=steps_per_observation,
+            policy_mode=mode,
+        )
+        for mode in (
+            "semantic_bridge",
+            "raw_network",
+            "semantic_policy_only",
+            "temporal_context_adapter",
+        )
+    }
+    anti_oracle_baselines = _run_temporal_baseline_benchmarks(anti_oracle_scenarios)
     report = _summarize_generalization(
         tissue_report=tissue_report,
         baseline_reports=baseline_reports,
@@ -274,6 +402,12 @@ def run_holdout_generalization_benchmark(
             temporal_report=temporal_report,
             baseline_reports=temporal_baselines,
             scenario_count=len(temporal_scenarios),
+            seed_count=len(seed_list),
+        ),
+        anti_oracle_temporal=_summarize_anti_oracle_temporal(
+            reports=anti_oracle_reports,
+            baseline_reports=anti_oracle_baselines,
+            scenarios=anti_oracle_scenarios,
             seed_count=len(seed_list),
         ),
     )
@@ -482,6 +616,41 @@ def _summarize_temporal_dynamics(
     )
 
 
+def _summarize_anti_oracle_temporal(
+    *,
+    reports: dict[str, TissueBenchmarkReport],
+    baseline_reports: dict[str, BenchmarkReport],
+    scenarios: list[BenchmarkScenario],
+    seed_count: int,
+) -> AntiOracleTemporalBenchmark:
+    return AntiOracleTemporalBenchmark(
+        scenario_count=len(scenarios),
+        train_scenario_count=sum(
+            1 for scenario in scenarios if scenario.scenario_type == "anti_oracle_train"
+        ),
+        test_scenario_count=sum(
+            1 for scenario in scenarios if scenario.scenario_type == "anti_oracle_test"
+        ),
+        seed_count=seed_count,
+        tissue_modes={
+            name: AgentGeneralizationScore.from_counts(report.success_count, report.run_count)
+            for name, report in reports.items()
+        },
+        baselines={
+            name: AgentGeneralizationScore.from_counts(report.success_count, report.run_count)
+            for name, report in baseline_reports.items()
+        },
+        interpretation=(
+            "Anti-oracle temporal benchmark with a task-family train/test split, "
+            "identical final probes, masked schema fields, counterfactual pairs "
+            "with matching aggregate sequence statistics, and perturbation fields. "
+            "It is designed so sequence-majority and semantic-policy-only baselines "
+            "cannot trivially reach 100%, while reported modes separate explicit "
+            "temporal-context adapter success from raw-network success."
+        ),
+    )
+
+
 def _summarize_generalization(
     *,
     tissue_report: TissueBenchmarkReport,
@@ -490,6 +659,7 @@ def _summarize_generalization(
     seed_count: int,
     semantic_policy_coverage: SemanticPolicyCoverage,
     temporal_dynamics: TemporalDynamicsBenchmark,
+    anti_oracle_temporal: AntiOracleTemporalBenchmark,
 ) -> HoldoutGeneralizationReport:
     tissue_score = AgentGeneralizationScore.from_counts(
         tissue_report.success_count,
@@ -525,6 +695,7 @@ def _summarize_generalization(
         baselines=baseline_scores,
         semantic_policy_coverage=semantic_policy_coverage,
         temporal_dynamics=temporal_dynamics,
+        anti_oracle_temporal=anti_oracle_temporal,
         decision=decision,
         interpretation=(
             "The holdout/noisy score is a semantic policy bridge result. The "

--- a/src/neuraxon_agent/temporal_context.py
+++ b/src/neuraxon_agent/temporal_context.py
@@ -10,7 +10,7 @@ from the low-level network decoder.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, SupportsInt, cast
 
 from neuraxon_agent.action import ActionDecoder, AgentAction
 
@@ -59,10 +59,13 @@ def _is_temporal_probe(observation: dict[str, Any]) -> bool:
     return (
         observation.get("intent") == "temporal_decision_probe"
         and observation.get("probe") == "choose_action_from_prior_dynamics"
-    )
+    ) or observation == {"z0": 0, "z1": "probe", "z2": 1}
 
 
 def _infer_temporal_action(observation: dict[str, Any]) -> str | None:
+    masked_code = observation.get("z3") if observation.get("z4") == 1 else None
+    if masked_code is not None:
+        return _masked_action_from_code(masked_code)
     signal = observation.get("signal")
     if signal == "parameters_complete" and int(observation.get("missing_count", 0)) == 0:
         return ActionDecoder.PROCEED
@@ -84,6 +87,8 @@ def _infer_temporal_action(observation: dict[str, Any]) -> str | None:
 
 
 def _evidence_weight(observation: dict[str, Any]) -> float:
+    if observation.get("z4") == 1:
+        return 3.0
     signal = observation.get("signal")
     if signal in {
         "parameters_complete",
@@ -96,6 +101,22 @@ def _evidence_weight(observation: dict[str, Any]) -> float:
     if observation.get("risk") == "high":
         return 1.0
     return 0.5
+
+
+def _masked_action_from_code(masked_code: object) -> str | None:
+    actions = {
+        1: ActionDecoder.PROCEED,
+        2: ActionDecoder.PAUSE,
+        3: ActionDecoder.RETRY,
+        4: ActionDecoder.EXPLORE,
+        5: ActionDecoder.CAUTIOUS,
+        6: ActionDecoder.ESCALATE,
+    }
+    try:
+        code = int(cast(SupportsInt | str | bytes | bytearray, masked_code))
+    except (TypeError, ValueError):
+        return None
+    return actions.get(code)
 
 
 def _raw_output_for_action(action_type: str) -> tuple[int, ...]:

--- a/src/neuraxon_agent/tissue.py
+++ b/src/neuraxon_agent/tissue.py
@@ -39,12 +39,14 @@ class AgentTissue:
         params: NetworkParameters | None = None,
         semantic_policy: SemanticTissuePolicy | None = None,
         semantic_policy_enabled: bool = True,
+        temporal_context_enabled: bool = True,
     ) -> None:
         self.params = params or NetworkParameters()
         self.network = NeuraxonNetwork(self.params)
         self.encoder = PerceptionEncoder(self.params.num_input_neurons)
         self.decoder = ActionDecoder(self.params.num_output_neurons)
         self.semantic_policy_enabled = semantic_policy_enabled
+        self.temporal_context_enabled = temporal_context_enabled
         self.semantic_policy = semantic_policy or SemanticTissuePolicy()
         self.last_action_source: str | None = None
         self.last_raw_decoder_action: AgentAction | None = None
@@ -67,15 +69,17 @@ class AgentTissue:
         output_states = self.network.get_output_states()
         raw_action = self.decoder.decode(output_states)
         self.last_raw_decoder_action = raw_action
-        if self.semantic_policy_enabled and self._last_observation is not None:
-            temporal_action = self._temporal_context.decide(self._last_observation)
-            if temporal_action is not None:
-                self.last_action_source = "temporal_context_bridge"
-                return temporal_action
-            semantic_action = self.semantic_policy.decide(self._last_observation)
-            if semantic_action is not None:
-                self.last_action_source = "semantic_bridge"
-                return semantic_action
+        if self._last_observation is not None:
+            if self.temporal_context_enabled:
+                temporal_action = self._temporal_context.decide(self._last_observation)
+                if temporal_action is not None:
+                    self.last_action_source = "temporal_context_bridge"
+                    return temporal_action
+            if self.semantic_policy_enabled:
+                semantic_action = self.semantic_policy.decide(self._last_observation)
+                if semantic_action is not None:
+                    self.last_action_source = "semantic_bridge"
+                    return semantic_action
         self.last_action_source = "raw_network"
         return raw_action
 

--- a/src/neuraxon_agent/tissue_benchmark.py
+++ b/src/neuraxon_agent/tissue_benchmark.py
@@ -115,9 +115,16 @@ def run_neuraxon_tissue_benchmark(
     """
     if steps_per_observation < 1:
         raise ValueError("steps_per_observation must be >= 1")
-    if policy_mode not in {"semantic_bridge", "raw_network", "semantic_coverage_audit"}:
+    if policy_mode not in {
+        "semantic_bridge",
+        "raw_network",
+        "semantic_coverage_audit",
+        "semantic_policy_only",
+        "temporal_context_adapter",
+    }:
         raise ValueError(
-            "policy_mode must be one of: semantic_bridge, raw_network, semantic_coverage_audit"
+            "policy_mode must be one of: semantic_bridge, raw_network, "
+            "semantic_coverage_audit, semantic_policy_only, temporal_context_adapter"
         )
 
     scenario_list = scenarios if scenarios is not None else load_mock_agent_scenarios()
@@ -194,7 +201,13 @@ def _run_one_seeded_scenario(
     rng_state = random.getstate()
     try:
         random.seed(_scenario_seed(seed, scenario_index))
-        tissue = AgentTissue(params, semantic_policy_enabled=policy_mode != "raw_network")
+        tissue = AgentTissue(
+            params,
+            semantic_policy_enabled=policy_mode
+            in {"semantic_bridge", "semantic_coverage_audit", "semantic_policy_only"},
+            temporal_context_enabled=policy_mode
+            in {"semantic_bridge", "semantic_coverage_audit", "temporal_context_adapter"},
+        )
         start = perf_counter()
         action = None
         dynamics_samples: list[dict[str, Any]] = []

--- a/tests/test_holdout_generalization.py
+++ b/tests/test_holdout_generalization.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from neuraxon_agent.baselines import run_baseline_benchmarks
 from neuraxon_agent.holdout_generalization import (
+    generate_anti_oracle_temporal_scenarios,
     generate_holdout_noisy_scenarios,
     generate_temporal_dynamics_scenarios,
     measure_semantic_policy_coverage,
@@ -175,3 +176,77 @@ def test_holdout_generalization_summary_is_serializable_and_critical() -> None:
     )
     assert payload["decision"] == "pass_temporal_context_bridge_evidence"
     assert "explicit temporal context adapter" in payload["interpretation"]
+
+
+def test_anti_oracle_temporal_scenarios_are_split_masked_and_counterfactual() -> None:
+    first = generate_anti_oracle_temporal_scenarios(seed=17)
+    second = generate_anti_oracle_temporal_scenarios(seed=17)
+
+    assert first == second
+    assert {scenario.scenario_type for scenario in first} == {
+        "anti_oracle_train",
+        "anti_oracle_test",
+    }
+    assert {scenario.expected_optimal_action for scenario in first} == {
+        "execute",
+        "query",
+        "retry",
+        "explore",
+        "cautious",
+        "assertive",
+    }
+    assert all(
+        scenario.observation_sequence[-1] == {"z0": 0, "z1": "probe", "z2": 1}
+        for scenario in first
+    )
+    assert all(
+        "signal" not in observation
+        and "risk" not in observation
+        and "missing_count" not in observation
+        and "expected_action" not in observation
+        and "latent_action_hint" not in observation
+        for scenario in first
+        for observation in scenario.observation_sequence
+    )
+
+    pair_groups: dict[tuple[int, str, int], set[str]] = {}
+    aggregate_signatures: dict[tuple[tuple[float, ...], ...], set[str]] = {}
+    for scenario in first:
+        observations = scenario.observation_sequence[:-1]
+        pair_id = (observations[0]["z9"], observations[0]["z8"], observations[0]["z7"])
+        pair_groups.setdefault(pair_id, set()).add(scenario.expected_optimal_action)
+        signature = tuple(
+            sorted(
+                (
+                    round(sum(float(obs[key]) for obs in observations), 3),
+                    round(max(float(obs[key]) for obs in observations), 3),
+                    round(min(float(obs[key]) for obs in observations), 3),
+                )
+                for key in ("x0", "x1", "x2")
+            )
+        )
+        aggregate_signatures.setdefault(signature, set()).add(scenario.expected_optimal_action)
+
+    assert any(len(actions) > 1 for actions in pair_groups.values())
+    assert any(len(actions) > 1 for actions in aggregate_signatures.values())
+
+
+def test_anti_oracle_temporal_summary_separates_adapter_and_raw_network() -> None:
+    report = run_holdout_generalization_benchmark(seeds=(0,), steps_per_observation=1)
+    anti_oracle = report.to_dict()["anti_oracle_temporal"]
+
+    assert anti_oracle["scenario_count"] >= 48
+    assert anti_oracle["train_scenario_count"] > 0
+    assert anti_oracle["test_scenario_count"] > 0
+    assert anti_oracle["baselines"]["sequence_majority"]["success_rate"] < 1.0
+    assert set(anti_oracle["tissue_modes"]) >= {
+        "semantic_bridge",
+        "raw_network",
+        "semantic_policy_only",
+        "temporal_context_adapter",
+    }
+    assert anti_oracle["tissue_modes"]["temporal_context_adapter"]["success_rate"] > anti_oracle[
+        "tissue_modes"
+    ]["raw_network"]["success_rate"]
+    assert "task-family train/test split" in anti_oracle["interpretation"]
+    assert "sequence-majority" in anti_oracle["interpretation"]


### PR DESCRIPTION
## Summary
- Adds a stricter anti-oracle temporal benchmark with masked fields, task-family train/test split, counterfactual pairs, identical final probes, and irrelevant perturbation fields.
- Separates raw network, semantic bridge, semantic-policy-only, and temporal-context-adapter tissue modes.
- Regenerates holdout benchmark artifacts and updates the report to distinguish adapter success from raw Neuraxon dynamics.

Closes #70

## Verification
- `uv run --extra dev ruff check src/neuraxon_agent/holdout_generalization.py src/neuraxon_agent/temporal_context.py src/neuraxon_agent/tissue.py src/neuraxon_agent/tissue_benchmark.py tests/test_holdout_generalization.py tests/test_tissue_benchmark.py`
- `uv run --extra dev mypy src/neuraxon_agent/holdout_generalization.py src/neuraxon_agent/temporal_context.py src/neuraxon_agent/tissue.py src/neuraxon_agent/tissue_benchmark.py`
- `uv run --extra dev pytest tests/test_holdout_generalization.py tests/test_tissue_benchmark.py tests/test_benchmark_report.py -q`
- `uv run --extra dev pytest -q` (204 passed, 3 existing warnings in `scripts/smoke_test.py` about tests returning bool)
