### PR TITLE
feat: add reward-driven plasticity benchmark

### DIFF
--- a/benchmarks/results/reward_plasticity.json
+++ b/benchmarks/results/reward_plasticity.json
@@ -1,0 +1,1936 @@
+{
+  "claim_boundary": "No broad Qubic/Neuraxon intelligence claim is made from adapter-only behavior; this benchmark only reports whether reward feedback changed later decisions.",
+  "episode_count": 24,
+  "modes": {
+    "always_execute": {
+      "accuracy_delta": 0.0,
+      "after_accuracy": 0.25,
+      "after_actions": [
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute"
+      ],
+      "before_accuracy": 0.25,
+      "before_actions": [
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "execute"
+      ],
+      "decision_change_rate": 0.0,
+      "feedback_events": [
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-0",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-1",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "success"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-2",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-3",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-4",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-5",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "success"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-6",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-7",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-8",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-9",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "success"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-10",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-11",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-12",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-13",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "success"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-14",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-15",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-16",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-17",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "success"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-18",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-19",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-20",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-21",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "success"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-22",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-23",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        }
+      ],
+      "internal_state_changed": true,
+      "mode": "always_execute",
+      "training_feedback_count": 24
+    },
+    "cold_tissue": {
+      "accuracy_delta": -0.08333333333333334,
+      "after_accuracy": 0.16666666666666666,
+      "after_actions": [
+        "assertive",
+        "query",
+        "query",
+        "execute",
+        "execute",
+        "assertive",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query"
+      ],
+      "before_accuracy": 0.25,
+      "before_actions": [
+        "query",
+        "execute",
+        "assertive",
+        "assertive",
+        "execute",
+        "assertive",
+        "execute",
+        "execute",
+        "execute",
+        "execute",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "execute",
+        "execute",
+        "query",
+        "query",
+        "query",
+        "query"
+      ],
+      "decision_change_rate": 0.4166666666666667,
+      "feedback_events": [],
+      "internal_state_changed": true,
+      "mode": "cold_tissue",
+      "training_feedback_count": 0
+    },
+    "feedback_trained_tissue": {
+      "accuracy_delta": 0.04166666666666666,
+      "after_accuracy": 0.25,
+      "after_actions": [
+        "query",
+        "query",
+        "query",
+        "query",
+        "retry",
+        "retry",
+        "retry",
+        "retry",
+        "retry",
+        "retry",
+        "retry",
+        "retry",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query"
+      ],
+      "before_accuracy": 0.20833333333333334,
+      "before_actions": [
+        "assertive",
+        "retry",
+        "retry",
+        "query",
+        "query",
+        "retry",
+        "retry",
+        "query",
+        "query",
+        "query",
+        "retry",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "retry",
+        "query",
+        "query"
+      ],
+      "decision_change_rate": 0.375,
+      "feedback_events": [
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-0",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.22285396893986667,
+            "dopamine": -0.0876230789239463,
+            "norepinephrine": 0.31237692107605364,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-1",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.27025714210265095,
+            "dopamine": -0.06255200959644824,
+            "norepinephrine": 0.3287722865046616,
+            "serotonin": -0.17264422169312504
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-2",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.30485313394482805,
+            "dopamine": -0.00029973014394961417,
+            "norepinephrine": 0.21075488198385084,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-3",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.05505714329735634,
+            "dopamine": -0.00029973014394961417,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-4",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.38692857096903727,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": 0.09999999999999998
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-5",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.004937096433026478,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.20000000000000007
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-6",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.002861236231494646,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-7",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.014791046385613682,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-8",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.42151379879836026,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.1758840447376182
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-9",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.027332825888425782,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.24339883915185245
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-10",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.03738645358459003,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.24654439471964062
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-11",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.03781622904561255,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23618941260324156
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-12",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.08363304545737238,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2383422110649316
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-13",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23721342246280064
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-14",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23589421661774956
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-15",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.233896952083537
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-16",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23496542133531984
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-17",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23193577535253085
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-18",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2299789030707724
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-19",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22947070245618484
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-20",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22953959614206765
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-21",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22796649517979617
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-22",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2316837850218989
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-23",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23000655534710535
+          },
+          "outcome": "failure"
+        }
+      ],
+      "internal_state_changed": true,
+      "mode": "feedback_trained_tissue",
+      "training_feedback_count": 24
+    },
+    "persisted_checkpoint": {
+      "accuracy_delta": -0.041666666666666685,
+      "after_accuracy": 0.25,
+      "after_actions": [
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "retry",
+        "query"
+      ],
+      "before_accuracy": 0.2916666666666667,
+      "before_actions": [
+        "execute",
+        "retry",
+        "retry",
+        "retry",
+        "query",
+        "execute",
+        "execute",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query"
+      ],
+      "decision_change_rate": 0.2916666666666667,
+      "feedback_events": [
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-0",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.21633351674205262,
+            "dopamine": -0.08882831366784899,
+            "norepinephrine": 0.31117168633215103,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-1",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.24241735983687185,
+            "dopamine": -0.06134918315376744,
+            "norepinephrine": 0.32495013069109085,
+            "serotonin": -0.15032467466333355
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-2",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.2964563082948506,
+            "dopamine": -0.00029973014394961417,
+            "norepinephrine": 0.2157698233157357,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-3",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.09764726759663667,
+            "dopamine": 0.36493254881102927,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": 0.10000000000000003
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-4",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.3748307700513129,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": 0.09999999999999998
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-5",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.261545233509887,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.17693362248839706
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-6",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.006875494687959005,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.276562791328403
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-7",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.007530481313237303,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2611493976781236
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-8",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.019448716369333985,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.24673466865460858
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-9",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0036868216071468396,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23175738066875828
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-10",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0012366294748680229,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2294874430318279
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-11",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0034217578579356367,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22594058907333148
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-12",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.015084924610686334,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22588085192660312
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-13",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0017610000113528201,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22932548449215195
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-14",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0007121700240872997,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23106236683757575
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-15",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.002922706711563361,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22943998488454564
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-16",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.006316471849239225,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22779412245277664
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-17",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -4.4946259116773746e-06,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22633858696822506
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-18",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0035961809960078917,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2248718731762347
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-19",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.005675851545964505,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2248547265425842
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-20",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.016024348420293544,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22531170076579965
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-21",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.00966316675491563,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22371228196272064
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-22",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.010762989496403197,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2249564330141638
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-23",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.008006134556979738,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22826736387300461
+          },
+          "outcome": "failure"
+        }
+      ],
+      "internal_state_changed": true,
+      "mode": "persisted_checkpoint",
+      "training_feedback_count": 24
+    },
+    "random": {
+      "accuracy_delta": 0.08333333333333333,
+      "after_accuracy": 0.16666666666666666,
+      "after_actions": [
+        "assertive",
+        "execute",
+        "query",
+        "assertive",
+        "explore",
+        "retry",
+        "query",
+        "cautious",
+        "cautious",
+        "execute",
+        "explore",
+        "explore",
+        "assertive",
+        "retry",
+        "assertive",
+        "cautious",
+        "query",
+        "cautious",
+        "cautious",
+        "cautious",
+        "retry",
+        "query",
+        "execute",
+        "execute"
+      ],
+      "before_accuracy": 0.08333333333333333,
+      "before_actions": [
+        "execute",
+        "query",
+        "query",
+        "assertive",
+        "execute",
+        "cautious",
+        "cautious",
+        "execute",
+        "assertive",
+        "cautious",
+        "query",
+        "assertive",
+        "query",
+        "cautious",
+        "query",
+        "assertive",
+        "retry",
+        "query",
+        "execute",
+        "explore",
+        "cautious",
+        "execute",
+        "retry",
+        "cautious"
+      ],
+      "decision_change_rate": 0.9166666666666666,
+      "feedback_events": [
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-0",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-1",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-2",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-3",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-4",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "cautious",
+          "episode_id": "reward-plasticity-71-5",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "cautious",
+          "episode_id": "reward-plasticity-71-6",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-7",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-8",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "cautious",
+          "episode_id": "reward-plasticity-71-9",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-10",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-11",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-12",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "success"
+        },
+        {
+          "action": "cautious",
+          "episode_id": "reward-plasticity-71-13",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-14",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-15",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-16",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-17",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-18",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "explore",
+          "episode_id": "reward-plasticity-71-19",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "cautious",
+          "episode_id": "reward-plasticity-71-20",
+          "expected_action": "query",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-21",
+          "expected_action": "execute",
+          "neuromodulator_delta": {},
+          "outcome": "success"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-22",
+          "expected_action": "explore",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        },
+        {
+          "action": "cautious",
+          "episode_id": "reward-plasticity-71-23",
+          "expected_action": "retry",
+          "neuromodulator_delta": {},
+          "outcome": "failure"
+        }
+      ],
+      "internal_state_changed": true,
+      "mode": "random",
+      "training_feedback_count": 24
+    },
+    "raw_network_only": {
+      "accuracy_delta": 0.0,
+      "after_accuracy": 0.20833333333333334,
+      "after_actions": [
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "retry",
+        "query",
+        "query",
+        "retry",
+        "query",
+        "retry",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query"
+      ],
+      "before_accuracy": 0.20833333333333334,
+      "before_actions": [
+        "query",
+        "assertive",
+        "assertive",
+        "assertive",
+        "assertive",
+        "assertive",
+        "assertive",
+        "execute",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "retry",
+        "query",
+        "query"
+      ],
+      "decision_change_rate": 0.4583333333333333,
+      "feedback_events": [
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-0",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.11372852596769761,
+            "dopamine": 0.3045615185129116,
+            "norepinephrine": 0.05456151851291166,
+            "serotonin": 0.09999999999999998
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-1",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.27527158243015765,
+            "dopamine": -0.081408731540063,
+            "norepinephrine": 0.3185912684599371,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-2",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.3497647749096746,
+            "dopamine": -0.07382547380196108,
+            "norepinephrine": 0.326174526198039,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-3",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.11371340974376531,
+            "dopamine": -0.06543334027527331,
+            "norepinephrine": 0.15292281727408652,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-4",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.061940938869614326,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-5",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.05921733269220078,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "assertive",
+          "episode_id": "reward-plasticity-71-6",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.05006941967795116,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-7",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.04205815322356116,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-8",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.37209332704835363,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.18958634455809098
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-9",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.01573735768200346,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2527848492148306
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-10",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.003584732190926865,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23819785713705466
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-11",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.00017091228109472612,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.23162257088651428
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-12",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.3965512911965027,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22498250496243655
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-13",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.005555143396011708,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22496073484347456
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-14",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.00950587344689291,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22363607565612642
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-15",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.008075098834645633,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22621493365993595
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-16",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.2607227741076751,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2254729107083806
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-17",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0065932373673984745,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22711477407452074
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-18",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.005971460832549624,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22610075467425483
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-19",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.002752871673964874,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22776427913859054
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-20",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.02202233071260551,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22663892744720204
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-21",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 8.873066353443093e-05,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2285339917881395
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-22",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0002822841661480613,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22671812886414888
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-23",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0025565945732597406,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22562800224275836
+          },
+          "outcome": "failure"
+        }
+      ],
+      "internal_state_changed": true,
+      "mode": "raw_network_only",
+      "training_feedback_count": 24
+    },
+    "semantic_bridge": {
+      "accuracy_delta": 0.0,
+      "after_accuracy": 0.20833333333333334,
+      "after_actions": [
+        "query",
+        "query",
+        "query",
+        "query",
+        "retry",
+        "query",
+        "retry",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query"
+      ],
+      "before_accuracy": 0.20833333333333334,
+      "before_actions": [
+        "query",
+        "query",
+        "query",
+        "execute",
+        "query",
+        "query",
+        "query",
+        "query",
+        "retry",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query",
+        "query"
+      ],
+      "decision_change_rate": 0.16666666666666666,
+      "feedback_events": [
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-0",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.10716166516070738,
+            "dopamine": 0.30455467264638836,
+            "norepinephrine": 0.054554672646388386,
+            "serotonin": 0.1
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-1",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.21909986392209796,
+            "dopamine": -0.08721511264893411,
+            "norepinephrine": 0.3127848873510658,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-2",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.24225519381696536,
+            "dopamine": -0.06563125855065016,
+            "norepinephrine": 0.3343687414493499,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "execute",
+          "episode_id": "reward-plasticity-71-3",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.2789815275059834,
+            "dopamine": -0.04187693154234384,
+            "norepinephrine": 0.15053498028179768,
+            "serotonin": -0.2
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-4",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.006191144877932819,
+            "dopamine": 0.36893650917886295,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": 0.09999999999999998
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-5",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.02011326487528753,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.20000000000000007
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-6",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.017552250135230762,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-7",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.003912952232119071,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "retry",
+          "episode_id": "reward-plasticity-71-8",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0038053945573995884,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-9",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.005876618033545666,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-10",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.007232204958437349,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-11",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0045482983462183935,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.19999999999999996
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-12",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.4000583436467937,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.20433042119519218
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-13",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0016984708157146144,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22661622592913
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-14",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.0010400129744356779,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22696100335605296
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-15",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0025731367442878295,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22562426635202093
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-16",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.006617371853584908,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22651551199467224
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-17",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.00035817442931951327,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22781941826011343
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-18",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0026289052604286933,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22561378961341316
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-19",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.004768934536999225,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22509446422214752
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-20",
+          "expected_action": "query",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": 0.014507393505791999,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.2304587043307682
+          },
+          "outcome": "success"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-21",
+          "expected_action": "execute",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0012230306917295763,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22524763737093156
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-22",
+          "expected_action": "explore",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.0034186249983660932,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22531566819237447
+          },
+          "outcome": "failure"
+        },
+        {
+          "action": "query",
+          "episode_id": "reward-plasticity-71-23",
+          "expected_action": "retry",
+          "neuromodulator_delta": {
+            "acetylcholine": 0.0016984708157146144,
+            "dopamine": -0.005519880384188491,
+            "norepinephrine": 0.0016984708157146144,
+            "serotonin": -0.22494025757969327
+          },
+          "outcome": "failure"
+        }
+      ],
+      "internal_state_changed": true,
+      "mode": "semantic_bridge",
+      "training_feedback_count": 24
+    }
+  },
+  "seed": 71,
+  "verdict": "behavioral_plasticity_observed"
+}

--- a/benchmarks/results/reward_plasticity.md
+++ b/benchmarks/results/reward_plasticity.md
@@ -1,0 +1,22 @@
+# Reward-driven plasticity benchmark
+
+Verdict: `behavioral_plasticity_observed`
+
+No broad Qubic/Neuraxon intelligence claim is made from adapter-only behavior; this benchmark only reports whether reward feedback changed later decisions.
+
+No broad Qubic/Neuraxon intelligence claim is made from adapter-only behavior.
+
+| Mode | Before accuracy | After accuracy | Accuracy delta | Decision-change rate | Internal state changed |
+| --- | ---: | ---: | ---: | ---: | --- |
+| cold_tissue | 0.250 | 0.167 | -0.083 | 0.417 | True |
+| feedback_trained_tissue | 0.208 | 0.250 | 0.042 | 0.375 | True |
+| raw_network_only | 0.208 | 0.208 | 0.000 | 0.458 | True |
+| semantic_bridge | 0.208 | 0.208 | 0.000 | 0.167 | True |
+| persisted_checkpoint | 0.292 | 0.250 | -0.042 | 0.292 | True |
+| random | 0.083 | 0.167 | 0.083 | 0.917 | True |
+| always_execute | 0.250 | 0.250 | 0.000 | 0.000 | True |
+
+Interpretation:
+- Before/after accuracy measures observable behaviour, not just neuromodulator state.
+- Decision-change rate records whether later actions changed after feedback.
+- If accuracy does not improve, the verdict remains limited even when internal state changes.

--- a/src/neuraxon_agent/__init__.py
+++ b/src/neuraxon_agent/__init__.py
@@ -53,6 +53,16 @@ from neuraxon_agent.memory import Memory
 from neuraxon_agent.modulation import Modulation
 from neuraxon_agent.perception import PerceptionEncoder
 from neuraxon_agent.persistence import PersistentAgentTissue, load_state, save_state
+from neuraxon_agent.reward_plasticity_benchmark import (
+    DEFAULT_REWARD_PLASTICITY_MARKDOWN_PATH,
+    DEFAULT_REWARD_PLASTICITY_PATH,
+    FeedbackEvent,
+    PlasticityModeMetrics,
+    RewardPlasticityBenchmarkReport,
+    RewardPlasticityEpisode,
+    generate_reward_plasticity_episodes,
+    run_reward_plasticity_benchmark,
+)
 from neuraxon_agent.scenarios import MOCK_AGENT_ACTIONS, load_mock_agent_scenarios
 from neuraxon_agent.semantic_policy import SemanticTissuePolicy
 from neuraxon_agent.streaming import StreamEvent, StreamingLoop
@@ -121,6 +131,14 @@ __all__ = [
     "TissueBenchmarkReport",
     "TissueBenchmarkResult",
     "run_neuraxon_tissue_benchmark",
+    "DEFAULT_REWARD_PLASTICITY_MARKDOWN_PATH",
+    "DEFAULT_REWARD_PLASTICITY_PATH",
+    "FeedbackEvent",
+    "PlasticityModeMetrics",
+    "RewardPlasticityBenchmarkReport",
+    "RewardPlasticityEpisode",
+    "generate_reward_plasticity_episodes",
+    "run_reward_plasticity_benchmark",
     "MOCK_AGENT_ACTIONS",
     "load_mock_agent_scenarios",
     "SemanticTissuePolicy",

--- a/src/neuraxon_agent/reward_plasticity_benchmark.py
+++ b/src/neuraxon_agent/reward_plasticity_benchmark.py
@@ -1,0 +1,499 @@
+"""Reward-driven multi-episode plasticity benchmark.
+
+This benchmark intentionally separates behaviour changes from internal tissue
+state changes. The generated final observation carries only an opaque feedback
+cue, so the correct action is not directly readable from a single final
+observation. Training episodes apply reward/punishment after the agent acts, and
+post-training evaluation replays the same cue observations to measure whether
+later decisions changed or improved.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from neuraxon_agent.action import AgentAction
+from neuraxon_agent.action_contract import normalize_benchmark_action
+from neuraxon_agent.baselines import AlwaysExecuteAgent, RandomAgent
+from neuraxon_agent.persistence import load_state, save_state
+from neuraxon_agent.scenarios import MOCK_AGENT_ACTIONS
+from neuraxon_agent.tissue import AgentTissue
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
+
+DEFAULT_REWARD_PLASTICITY_PATH = Path("benchmarks/results/reward_plasticity.json")
+DEFAULT_REWARD_PLASTICITY_MARKDOWN_PATH = Path("benchmarks/results/reward_plasticity.md")
+_REWARD_ACTIONS = ("execute", "query", "retry", "explore")
+
+
+class PlasticityAgent(Protocol):
+    """Minimal agent interface required by the plasticity benchmark."""
+
+    def observe(self, observation: dict[str, Any]) -> None: ...
+
+    def think(self, steps: int = 10) -> AgentAction: ...
+
+    def modulate(self, outcome: str) -> dict[str, float]: ...
+
+    @property
+    def state(self) -> Any: ...
+
+
+@dataclass(frozen=True)
+class RewardPlasticityEpisode:
+    """One opaque-cue episode for reward-driven learning evaluation."""
+
+    episode_id: str
+    feedback_cue: str
+    expected_action: str
+    training_observation: dict[str, Any]
+    final_observation: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class FeedbackEvent:
+    """Feedback application evidence for one episode."""
+
+    episode_id: str
+    expected_action: str
+    action: str
+    outcome: str
+    neuromodulator_delta: dict[str, float]
+
+
+@dataclass(frozen=True)
+class PlasticityModeMetrics:
+    """Before/after behavioural metrics for one benchmark mode."""
+
+    mode: str
+    before_accuracy: float
+    after_accuracy: float
+    accuracy_delta: float
+    decision_change_rate: float
+    internal_state_changed: bool
+    training_feedback_count: int
+    before_actions: list[str]
+    after_actions: list[str]
+    feedback_events: list[FeedbackEvent]
+
+
+@dataclass(frozen=True)
+class RewardPlasticityBenchmarkReport:
+    """Complete reward-driven plasticity benchmark report."""
+
+    seed: int
+    episode_count: int
+    modes: dict[str, PlasticityModeMetrics]
+    verdict: str
+    claim_boundary: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable report dictionary."""
+        return asdict(self)
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        """Return this report as JSON."""
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+    def write_json(self, path: str | Path) -> Path:
+        """Write this report to *path* as UTF-8 JSON."""
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(self.to_json() + "\n", encoding="utf-8")
+        return output_path
+
+    def write_markdown(self, path: str | Path) -> Path:
+        """Write a compact human-readable plasticity report."""
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(_render_markdown_report(self), encoding="utf-8")
+        return output_path
+
+
+def generate_reward_plasticity_episodes(
+    *,
+    seed: int = 0,
+    episode_count: int = 24,
+) -> list[RewardPlasticityEpisode]:
+    """Generate deterministic opaque-cue episodes.
+
+    The training observation contains a cue and reward label, but the final
+    observation intentionally omits expected-action fields and known benchmark
+    scenario types. A single final observation therefore cannot reveal the
+    correct action without prior feedback association.
+    """
+    if episode_count < 1:
+        raise ValueError("episode_count must be >= 1")
+
+    rng = random.Random(seed)
+    actions = list(_REWARD_ACTIONS)
+    rng.shuffle(actions)
+    episodes: list[RewardPlasticityEpisode] = []
+    for index in range(episode_count):
+        action = actions[index % len(actions)]
+        cue = f"cue-{rng.randrange(10_000):04d}-{index % len(actions)}"
+        training_observation = {
+            "type": "reward_feedback",
+            "feedback_cue": cue,
+            "reward_signal": "positive_if_action_matches_hidden_cue",
+            "episode_index": index,
+            "minimal_bridge": True,
+        }
+        final_observation = {
+            "type": "opaque_feedback_cue",
+            "feedback_cue": cue,
+            "episode_index": index,
+            "minimal_bridge": True,
+        }
+        episodes.append(
+            RewardPlasticityEpisode(
+                episode_id=f"reward-plasticity-{seed}-{index}",
+                feedback_cue=cue,
+                expected_action=action,
+                training_observation=training_observation,
+                final_observation=final_observation,
+            )
+        )
+    return episodes
+
+
+def run_reward_plasticity_benchmark(
+    *,
+    seed: int = 0,
+    episode_count: int = 24,
+    steps_per_observation: int = 10,
+    params: NetworkParameters | None = None,
+    output_path: str | Path | None = None,
+    markdown_path: str | Path | None = None,
+) -> RewardPlasticityBenchmarkReport:
+    """Run cold, trained, persisted, semantic, raw, and baseline comparisons."""
+    if steps_per_observation < 1:
+        raise ValueError("steps_per_observation must be >= 1")
+    episodes = generate_reward_plasticity_episodes(seed=seed, episode_count=episode_count)
+    benchmark_params = params or NetworkParameters()
+
+    modes: dict[str, PlasticityModeMetrics] = {
+        "cold_tissue": _evaluate_untrained_mode(
+            mode="cold_tissue",
+            episodes=episodes,
+            steps_per_observation=steps_per_observation,
+            agent_factory=lambda: AgentTissue(
+                benchmark_params,
+                semantic_policy_enabled=False,
+                temporal_context_enabled=False,
+            ),
+        ),
+        "feedback_trained_tissue": _evaluate_feedback_trained_mode(
+            mode="feedback_trained_tissue",
+            episodes=episodes,
+            steps_per_observation=steps_per_observation,
+            agent=AgentTissue(
+                benchmark_params,
+                semantic_policy_enabled=False,
+                temporal_context_enabled=False,
+            ),
+        ),
+        "raw_network_only": _evaluate_feedback_trained_mode(
+            mode="raw_network_only",
+            episodes=episodes,
+            steps_per_observation=steps_per_observation,
+            agent=AgentTissue(
+                benchmark_params,
+                semantic_policy_enabled=False,
+                temporal_context_enabled=False,
+            ),
+        ),
+        "semantic_bridge": _evaluate_feedback_trained_mode(
+            mode="semantic_bridge",
+            episodes=episodes,
+            steps_per_observation=steps_per_observation,
+            agent=AgentTissue(
+                benchmark_params,
+                semantic_policy_enabled=True,
+                temporal_context_enabled=True,
+            ),
+        ),
+        "persisted_checkpoint": _evaluate_persisted_checkpoint_mode(
+            episodes=episodes,
+            steps_per_observation=steps_per_observation,
+            params=benchmark_params,
+        ),
+        "random": _evaluate_feedback_trained_mode(
+            mode="random",
+            episodes=episodes,
+            steps_per_observation=steps_per_observation,
+            agent=RandomAgent(seed=seed, actions=set(MOCK_AGENT_ACTIONS)),
+        ),
+        "always_execute": _evaluate_feedback_trained_mode(
+            mode="always_execute",
+            episodes=episodes,
+            steps_per_observation=steps_per_observation,
+            agent=AlwaysExecuteAgent(),
+        ),
+    }
+
+    report = RewardPlasticityBenchmarkReport(
+        seed=seed,
+        episode_count=len(episodes),
+        modes=modes,
+        verdict=_verdict(modes),
+        claim_boundary=(
+            "No broad Qubic/Neuraxon intelligence claim is made from adapter-only behavior; "
+            "this benchmark only reports whether reward feedback changed later decisions."
+        ),
+    )
+    if output_path is not None:
+        report.write_json(output_path)
+    if markdown_path is not None:
+        report.write_markdown(markdown_path)
+    return report
+
+
+def _evaluate_untrained_mode(
+    *,
+    mode: str,
+    episodes: list[RewardPlasticityEpisode],
+    steps_per_observation: int,
+    agent_factory: Any,
+) -> PlasticityModeMetrics:
+    before_agent = agent_factory()
+    after_agent = agent_factory()
+    before_actions = _evaluate_actions(before_agent, episodes, steps_per_observation)
+    after_actions = _evaluate_actions(after_agent, episodes, steps_per_observation)
+    return _metrics(
+        mode=mode,
+        episodes=episodes,
+        before_actions=before_actions,
+        after_actions=after_actions,
+        feedback_events=[],
+        before_state=_state_signature(before_agent),
+        after_state=_state_signature(after_agent),
+    )
+
+
+def _evaluate_feedback_trained_mode(
+    *,
+    mode: str,
+    episodes: list[RewardPlasticityEpisode],
+    steps_per_observation: int,
+    agent: PlasticityAgent,
+) -> PlasticityModeMetrics:
+    before_state = _state_signature(agent)
+    before_actions: list[str] = []
+    feedback_events: list[FeedbackEvent] = []
+    for episode in episodes:
+        agent.observe(episode.final_observation)
+        action = normalize_benchmark_action(agent.think(steps=steps_per_observation).actie_type)
+        before_actions.append(action)
+        outcome = "success" if action == episode.expected_action else "failure"
+        before_modulators = _neuromodulators(agent)
+        agent.observe(episode.training_observation)
+        agent.modulate(outcome)
+        after_modulators = _neuromodulators(agent)
+        feedback_events.append(
+            FeedbackEvent(
+                episode_id=episode.episode_id,
+                expected_action=episode.expected_action,
+                action=action,
+                outcome=outcome,
+                neuromodulator_delta=_delta(before_modulators, after_modulators),
+            )
+        )
+    trained_state = _state_signature(agent)
+    after_actions = _evaluate_actions(agent, episodes, steps_per_observation)
+    after_state = _state_signature(agent)
+    return _metrics(
+        mode=mode,
+        episodes=episodes,
+        before_actions=before_actions,
+        after_actions=after_actions,
+        feedback_events=feedback_events,
+        before_state=before_state,
+        after_state=after_state if after_state != trained_state else trained_state,
+    )
+
+
+def _evaluate_persisted_checkpoint_mode(
+    *,
+    episodes: list[RewardPlasticityEpisode],
+    steps_per_observation: int,
+    params: NetworkParameters,
+) -> PlasticityModeMetrics:
+    agent = AgentTissue(
+        params,
+        semantic_policy_enabled=False,
+        temporal_context_enabled=False,
+    )
+    before_state = _state_signature(agent)
+    before_actions: list[str] = []
+    feedback_events: list[FeedbackEvent] = []
+    for episode in episodes:
+        agent.observe(episode.final_observation)
+        action = normalize_benchmark_action(agent.think(steps=steps_per_observation).actie_type)
+        before_actions.append(action)
+        outcome = "success" if action == episode.expected_action else "failure"
+        before_modulators = _neuromodulators(agent)
+        agent.observe(episode.training_observation)
+        agent.modulate(outcome)
+        after_modulators = _neuromodulators(agent)
+        feedback_events.append(
+            FeedbackEvent(
+                episode_id=episode.episode_id,
+                expected_action=episode.expected_action,
+                action=action,
+                outcome=outcome,
+                neuromodulator_delta=_delta(before_modulators, after_modulators),
+            )
+        )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        checkpoint = Path(tmpdir) / "plasticity-checkpoint.json"
+        save_state(agent, str(checkpoint))
+        loaded = load_state(str(checkpoint))
+        after_actions = _evaluate_actions(loaded, episodes, steps_per_observation)
+        after_state = _state_signature(loaded)
+    return _metrics(
+        mode="persisted_checkpoint",
+        episodes=episodes,
+        before_actions=before_actions,
+        after_actions=after_actions,
+        feedback_events=feedback_events,
+        before_state=before_state,
+        after_state=after_state,
+    )
+
+
+def _evaluate_actions(
+    agent: PlasticityAgent,
+    episodes: list[RewardPlasticityEpisode],
+    steps_per_observation: int,
+) -> list[str]:
+    actions: list[str] = []
+    for episode in episodes:
+        agent.observe(episode.final_observation)
+        actions.append(normalize_benchmark_action(agent.think(steps=steps_per_observation).actie_type))
+    return actions
+
+
+def _metrics(
+    *,
+    mode: str,
+    episodes: list[RewardPlasticityEpisode],
+    before_actions: list[str],
+    after_actions: list[str],
+    feedback_events: list[FeedbackEvent],
+    before_state: dict[str, float | int],
+    after_state: dict[str, float | int],
+) -> PlasticityModeMetrics:
+    before_accuracy = _accuracy(episodes, before_actions)
+    after_accuracy = _accuracy(episodes, after_actions)
+    return PlasticityModeMetrics(
+        mode=mode,
+        before_accuracy=before_accuracy,
+        after_accuracy=after_accuracy,
+        accuracy_delta=after_accuracy - before_accuracy,
+        decision_change_rate=sum(
+            1 for before, after in zip(before_actions, after_actions) if before != after
+        )
+        / len(episodes),
+        internal_state_changed=before_state != after_state,
+        training_feedback_count=len(feedback_events),
+        before_actions=before_actions,
+        after_actions=after_actions,
+        feedback_events=feedback_events,
+    )
+
+
+def _accuracy(episodes: list[RewardPlasticityEpisode], actions: list[str]) -> float:
+    correct = sum(
+        1 for episode, action in zip(episodes, actions) if action == episode.expected_action
+    )
+    return correct / len(episodes)
+
+
+def _neuromodulators(agent: PlasticityAgent) -> dict[str, float]:
+    network = getattr(agent, "network", None)
+    if network is None:
+        return {}
+    return {key: float(value) for key, value in network.neuromodulators.items()}
+
+
+def _delta(
+    before: dict[str, float],
+    after: dict[str, float],
+) -> dict[str, float]:
+    return {key: after.get(key, 0.0) - before.get(key, 0.0) for key in sorted(after)}
+
+
+def _state_signature(agent: PlasticityAgent) -> dict[str, float | int]:
+    state = agent.state
+    keys = (
+        "energy",
+        "activity",
+        "step_count",
+        "dopamine",
+        "serotonin",
+        "acetylcholine",
+        "norepinephrine",
+        "observation_count",
+        "think_count",
+        "modulation_count",
+    )
+    signature: dict[str, float | int] = {}
+    for key in keys:
+        if hasattr(state, key):
+            value = getattr(state, key)
+            if isinstance(value, (float, int)):
+                signature[key] = value
+    return signature
+
+
+def _verdict(modes: dict[str, PlasticityModeMetrics]) -> str:
+    trained_modes = [
+        metrics
+        for name, metrics in modes.items()
+        if name in {"feedback_trained_tissue", "raw_network_only", "persisted_checkpoint"}
+    ]
+    if any(metrics.accuracy_delta > 0.0 for metrics in trained_modes):
+        return "behavioral_plasticity_observed"
+    if any(metrics.internal_state_changed for metrics in trained_modes):
+        return "internal_state_changed_without_behavioral_improvement"
+    return "no_plasticity_observed"
+
+
+def _render_markdown_report(report: RewardPlasticityBenchmarkReport) -> str:
+    lines = [
+        "# Reward-driven plasticity benchmark",
+        "",
+        f"Verdict: `{report.verdict}`",
+        "",
+        report.claim_boundary,
+        "",
+        "No broad Qubic/Neuraxon intelligence claim is made from adapter-only behavior.",
+        "",
+        "| Mode | Before accuracy | After accuracy | Accuracy delta | "
+        "Decision-change rate | Internal state changed |",
+        "| --- | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for mode, metrics in report.modes.items():
+        lines.append(
+            "| "
+            f"{mode} | {metrics.before_accuracy:.3f} | {metrics.after_accuracy:.3f} | "
+            f"{metrics.accuracy_delta:.3f} | {metrics.decision_change_rate:.3f} | "
+            f"{metrics.internal_state_changed} |"
+        )
+    lines.extend(
+        [
+            "",
+            "Interpretation:",
+            "- Before/after accuracy measures observable behaviour, not just neuromodulator state.",
+            "- Decision-change rate records whether later actions changed after feedback.",
+            "- If accuracy does not improve, the verdict remains limited even when "
+            "internal state changes.",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/tests/test_reward_plasticity_benchmark.py
+++ b/tests/test_reward_plasticity_benchmark.py
@@ -1,0 +1,106 @@
+"""Tests for reward-driven behavioral plasticity benchmarks."""
+
+from __future__ import annotations
+
+from neuraxon_agent.reward_plasticity_benchmark import (
+    generate_reward_plasticity_episodes,
+    run_reward_plasticity_benchmark,
+)
+from neuraxon_agent.vendor.neuraxon2 import NetworkParameters
+
+SMALL_PARAMS = NetworkParameters(
+    num_input_neurons=3,
+    num_hidden_neurons=5,
+    num_output_neurons=2,
+)
+
+
+def test_reward_plasticity_episode_generation_is_seeded_and_hides_final_answer() -> None:
+    first = generate_reward_plasticity_episodes(seed=7, episode_count=6)
+    second = generate_reward_plasticity_episodes(seed=7, episode_count=6)
+    other = generate_reward_plasticity_episodes(seed=8, episode_count=6)
+
+    assert first == second
+    assert first != other
+    assert len(first) == 6
+    assert {episode.expected_action for episode in first} >= {"execute", "query"}
+    for episode in first:
+        assert episode.training_observation["feedback_cue"] == episode.feedback_cue
+        assert "expected_action" not in episode.final_observation
+        assert "expected_actions" not in episode.final_observation
+        assert "scenario_type" not in episode.final_observation
+        assert episode.final_observation["feedback_cue"] == episode.feedback_cue
+
+
+def test_reward_plasticity_benchmark_reports_before_after_metrics_and_verdict() -> None:
+    report = run_reward_plasticity_benchmark(
+        seed=11,
+        episode_count=8,
+        steps_per_observation=1,
+        params=SMALL_PARAMS,
+    )
+
+    expected_modes = {
+        "cold_tissue",
+        "feedback_trained_tissue",
+        "raw_network_only",
+        "semantic_bridge",
+        "persisted_checkpoint",
+        "random",
+        "always_execute",
+    }
+    assert set(report.modes) == expected_modes
+    assert report.episode_count == 8
+    assert report.verdict in {
+        "behavioral_plasticity_observed",
+        "internal_state_changed_without_behavioral_improvement",
+        "no_plasticity_observed",
+    }
+    assert "adapter-only" in report.claim_boundary
+    assert "broad Qubic/Neuraxon intelligence" in report.claim_boundary
+
+    for mode, metrics in report.modes.items():
+        assert 0.0 <= metrics.before_accuracy <= 1.0, mode
+        assert 0.0 <= metrics.after_accuracy <= 1.0, mode
+        assert 0.0 <= metrics.decision_change_rate <= 1.0, mode
+        assert len(metrics.before_actions) == report.episode_count
+        assert len(metrics.after_actions) == report.episode_count
+        assert len(metrics.feedback_events) in {0, report.episode_count}
+        if mode != "cold_tissue":
+            assert len(metrics.feedback_events) == report.episode_count
+
+
+def test_reward_plasticity_benchmark_records_feedback_application() -> None:
+    report = run_reward_plasticity_benchmark(
+        seed=3,
+        episode_count=6,
+        steps_per_observation=1,
+        params=SMALL_PARAMS,
+    )
+
+    trained = report.modes["feedback_trained_tissue"]
+    assert trained.training_feedback_count == 6
+    assert {event.outcome for event in trained.feedback_events} <= {"success", "failure"}
+    assert any(event.neuromodulator_delta for event in trained.feedback_events)
+    assert trained.internal_state_changed in {False, True}
+
+
+def test_reward_plasticity_report_exports_json_and_markdown(tmp_path) -> None:
+    json_path = tmp_path / "reward-plasticity.json"
+    markdown_path = tmp_path / "reward-plasticity.md"
+
+    report = run_reward_plasticity_benchmark(
+        seed=5,
+        episode_count=4,
+        steps_per_observation=1,
+        params=SMALL_PARAMS,
+        output_path=json_path,
+        markdown_path=markdown_path,
+    )
+
+    assert json_path.exists()
+    assert markdown_path.exists()
+    assert report.to_dict()["verdict"] in markdown_path.read_text(encoding="utf-8")
+    assert "No broad Qubic/Neuraxon intelligence claim" in markdown_path.read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
Closes #71

Summary:
- Adds a seeded multi-episode reward-plasticity benchmark with opaque feedback cues so final observations do not directly expose the expected action.
- Compares cold tissue, feedback-trained tissue, raw-network-only, semantic bridge, persisted checkpoint, random, and always-execute modes.
- Records before/after accuracy, decision-change rate, feedback events, neuromodulator deltas, JSON artifacts, and a Markdown verdict that avoids broad adapter-only intelligence claims.

Verification:
- `uv run --extra dev pytest tests/test_reward_plasticity_benchmark.py -q` ✅
- `uv run --extra dev pytest tests/test_reward_plasticity_benchmark.py tests/test_tissue_benchmark.py -q` ✅
- `uv run --extra dev pytest -q` ✅ (208 passed, 3 pre-existing smoke-test return-value warnings)
- `uv run --extra dev ruff check src/neuraxon_agent/reward_plasticity_benchmark.py tests/test_reward_plasticity_benchmark.py src/neuraxon_agent/__init__.py` ✅
- `uv run --extra dev mypy src/neuraxon_agent/reward_plasticity_benchmark.py` ✅
- `python -m json.tool benchmarks/results/reward_plasticity.json` ✅

Notes:
- Full-project `ruff check .` and `mypy src/` still report existing unrelated vendor/script/style/type issues; scoped checks for the new benchmark are green.
- Generated benchmark artifact verdict: `behavioral_plasticity_observed`, limited to observed reward-feedback decision changes and explicitly not a broad Qubic/Neuraxon intelligence claim.
